### PR TITLE
feat: add an email transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ source:
           transformer: random-date
         - name: first_name
           transformer: first-name
+        - name: email
+          transformer: email
 bridge:
   bucket: $BUCKET_NAME
   access_key_id: $ACCESS_KEY_ID

--- a/TRANSFORMERS.md
+++ b/TRANSFORMERS.md
@@ -3,7 +3,8 @@
 Here is a list of all the transformers available.
 
 | id         | description                                                          | available |
-|------------|----------------------------------------------------------------------|-----------|
+| ---------- | -------------------------------------------------------------------- | --------- |
 | transient  | Does not modify the value                                            | yes       |
 | random     | Randomize value but keep the same length (string only). [AAA]->[BBB] | yes       |
 | first-name | Replace the string value by a first name                             | yes       |
+| email      | Replace the string value by an email address                         | yes       |

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -1,3 +1,4 @@
+use crate::transformer::email::EmailTransformer;
 use crate::transformer::first_name::FirstNameTransformer;
 use crate::transformer::random::RandomTransformer;
 use crate::transformer::Transformer;
@@ -129,6 +130,8 @@ pub enum TransformerTypeConfig {
     RandomDate,
     #[serde(rename = "first-name")]
     FirstName,
+    #[serde(rename = "email")]
+    Email,
 }
 
 impl TransformerTypeConfig {
@@ -145,6 +148,11 @@ impl TransformerTypeConfig {
                 column_name,
             )),
             TransformerTypeConfig::FirstName => Box::new(FirstNameTransformer::new(
+                database_name,
+                table_name,
+                column_name,
+            )),
+            TransformerTypeConfig::Email => Box::new(EmailTransformer::new(
                 database_name,
                 table_name,
                 column_name,

--- a/replibyte/src/transformer/email.rs
+++ b/replibyte/src/transformer/email.rs
@@ -1,0 +1,116 @@
+use crate::transformer::Transformer;
+use crate::types::Column;
+use fake::faker::internet::raw::SafeEmail;
+use fake::locales::EN;
+use fake::Fake;
+
+/// This struct is dedicated to replacing a string by an email address.
+pub struct EmailTransformer {
+    database_name: String,
+    table_name: String,
+    column_name: String,
+}
+
+impl EmailTransformer {
+    pub fn new<S>(database_name: S, table_name: S, column_name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        EmailTransformer {
+            database_name: database_name.into(),
+            table_name: table_name.into(),
+            column_name: column_name.into(),
+        }
+    }
+}
+
+impl Transformer for EmailTransformer {
+    fn id(&self) -> &str {
+        "email"
+    }
+
+    fn description(&self) -> &str {
+        "Generate an email address (string only). [john.doe@company.com]->[tony.stark@avengers.com]"
+    }
+
+    fn database_name(&self) -> &str {
+        self.database_name.as_str()
+    }
+
+    fn table_name(&self) -> &str {
+        self.table_name.as_str()
+    }
+
+    fn column_name(&self) -> &str {
+        self.column_name.as_str()
+    }
+
+    fn transform(&self, column: Column) -> Column {
+        match column {
+            Column::StringValue(column_name, value) => {
+                let new_value = match value.len() {
+                    len if len == 0 => value,
+                    _ => SafeEmail(EN).fake(),
+                };
+
+                Column::StringValue(column_name, new_value)
+            }
+            column => column,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{transformer::Transformer, types::Column};
+
+    use super::EmailTransformer;
+
+    #[test]
+    fn transform_email_with_number_value() {
+        let expected_value = 34;
+        let transformer = get_transformer();
+        let column = Column::NumberValue("email".to_string(), expected_value);
+        let transformed_column = transformer.transform(column);
+        let transformed_value = transformed_column.number_value().unwrap();
+
+        assert_eq!(transformed_value.to_owned(), expected_value)
+    }
+
+    #[test]
+    fn transform_email_with_float_value() {
+        let expected_value = 1.5;
+        let transformer = get_transformer();
+        let column = Column::FloatNumberValue("email".to_string(), expected_value);
+        let transformed_column = transformer.transform(column);
+        let transformed_value = transformed_column.float_number_value().unwrap();
+
+        assert_eq!(transformed_value.to_owned(), expected_value)
+    }
+
+    #[test]
+    fn transform_email_with_empty_string_value() {
+        let expected_value = "";
+        let transformer = get_transformer();
+        let column = Column::StringValue("email".to_string(), expected_value.to_string());
+        let transformed_column = transformer.transform(column);
+        let transformed_value = transformed_column.string_value().unwrap();
+
+        assert_eq!(transformed_value, expected_value)
+    }
+
+    #[test]
+    fn transform_email_with_string_value() {
+        let transformer = get_transformer();
+        let column = Column::StringValue("email".to_string(), "john.doe@company.com".to_string());
+        let transformed_column = transformer.transform(column);
+        let transformed_value = transformed_column.string_value().unwrap();
+
+        assert!(!transformed_value.is_empty());
+        assert_ne!(transformed_value, "john.doe@company.com".to_string());
+    }
+
+    fn get_transformer() -> EmailTransformer {
+        EmailTransformer::new("github", "users", "email")
+    }
+}

--- a/replibyte/src/transformer/mod.rs
+++ b/replibyte/src/transformer/mod.rs
@@ -1,5 +1,6 @@
 use crate::types::Column;
 
+pub mod email;
 pub mod first_name;
 pub mod random;
 pub mod transient;
@@ -8,6 +9,7 @@ pub enum Transformers {
     Random,
     Transient,
     FirstName,
+    Email,
 }
 
 /// Trait to implement to create a custom Transformer.


### PR DESCRIPTION
Hi @evoxmusic 
I thought an email transformer would be a good idea, there are often a need to remove real email addresses from production databases. So here is a pull request. 

I've added some tests but there is some tests which failed because i'm missing some environment variables like `AWS_ACCESS_KEY_ID` ...

Maybe I could setup a [minio server](https://min.io/) or another open source S3 compatible solution inside docker-compose.yml, I could do that in another pull request ? 