### PR TITLE
fix: typo in transformer list description subcommand

### DIFF
--- a/replibyte/src/cli.rs
+++ b/replibyte/src/cli.rs
@@ -44,7 +44,7 @@ pub enum BackupCommand {
 /// all transformer commands
 #[derive(Subcommand, Debug)]
 pub enum TransformerCommand {
-    /// list available backups
+    /// list available transformers
     List,
 }
 


### PR DESCRIPTION
Hello

There is a typo in the description in the transformer subcommand

```
./target/debug/replibyte -c ./examples/source-postgres-bridge-minio.yaml transformer
...
SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    list    list available backups
```

It displays `backup` instead of `transformers`

This PR changes the description