### PR TITLE
Base redacted transformer

### DIFF
--- a/TRANSFORMERS.md
+++ b/TRANSFORMERS.md
@@ -2,12 +2,13 @@
 
 Here is a list of all the transformers available.
 
-| id              | description                                                          | available |
-| --------------- | -------------------------------------------------------------------- | --------- |
-| transient       | Does not modify the value                                            | yes       |
-| random          | Randomize value but keep the same length (string only). [AAA]->[BBB] | yes       |
-| first-name      | Replace the string value by a first name                             | yes       |
-| email           | Replace the string value by an email address                         | yes       |
-| keep-first-char | Keep only the first char for strings and digit for numbers           | yes       |
-| phone-number    | Replace the string value by a phone number                           | yes       |
-| credit-card     | Replace the string value by a credit card number                     | yes       |
+| id              | description                                                                                        | available |
+| --------------- | -------------------------------------------------------------------------------------------------- | --------- |
+| transient       | Does not modify the value                                                                          | yes       |
+| random          | Randomize value but keep the same length (string only). [AAA]->[BBB]                               | yes       |
+| first-name      | Replace the string value by a first name                                                           | yes       |
+| email           | Replace the string value by an email address                                                       | yes       |
+| keep-first-char | Keep only the first char for strings and digit for numbers                                         | yes       |
+| phone-number    | Replace the string value by a phone number                                                         | yes       |
+| credit-card     | Replace the string value by a credit card number                                                   | yes       |
+| redacted        | Obfuscate your sensitive data (>3 characters strings only). [4242 4242 4242 4242]->[424**********] | yes       |

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -4,6 +4,7 @@ use crate::transformer::first_name::FirstNameTransformer;
 use crate::transformer::keep_first_char::KeepFirstCharTransformer;
 use crate::transformer::phone_number::PhoneNumberTransformer;
 use crate::transformer::random::RandomTransformer;
+use crate::transformer::redacted::RedactedTransformer;
 use crate::transformer::Transformer;
 use serde;
 use serde::{Deserialize, Serialize};
@@ -166,6 +167,8 @@ pub enum TransformerTypeConfig {
     PhoneNumber,
     #[serde(rename = "credit-card")]
     CreditCard,
+    #[serde(rename = "redacted")]
+    Redacted,
 }
 
 impl TransformerTypeConfig {
@@ -203,6 +206,11 @@ impl TransformerTypeConfig {
             )),
             TransformerTypeConfig::RandomDate => todo!(),
             TransformerTypeConfig::CreditCard => Box::new(CreditCardTransformer::new(
+                database_name,
+                table_name,
+                column_name,
+            )),
+            TransformerTypeConfig::Redacted => Box::new(RedactedTransformer::new(
                 database_name,
                 table_name,
                 column_name,

--- a/replibyte/src/transformer/mod.rs
+++ b/replibyte/src/transformer/mod.rs
@@ -4,6 +4,7 @@ use crate::transformer::first_name::FirstNameTransformer;
 use crate::transformer::keep_first_char::KeepFirstCharTransformer;
 use crate::transformer::phone_number::PhoneNumberTransformer;
 use crate::transformer::random::RandomTransformer;
+use crate::transformer::redacted::RedactedTransformer;
 use crate::transformer::transient::TransientTransformer;
 use crate::types::Column;
 
@@ -13,6 +14,7 @@ pub mod first_name;
 pub mod keep_first_char;
 pub mod phone_number;
 pub mod random;
+pub mod redacted;
 pub mod transient;
 
 pub fn transformers() -> Vec<Box<dyn Transformer>> {
@@ -24,6 +26,7 @@ pub fn transformers() -> Vec<Box<dyn Transformer>> {
         Box::new(KeepFirstCharTransformer::default()),
         Box::new(TransientTransformer::default()),
         Box::new(CreditCardTransformer::default()),
+        Box::new(RedactedTransformer::default()),
     ]
 }
 

--- a/replibyte/src/transformer/redacted.rs
+++ b/replibyte/src/transformer/redacted.rs
@@ -86,6 +86,15 @@ mod tests {
         assert_eq!(transformed_value.to_owned(), "424**********")
     }
 
+    #[test]
+    fn strings_lower_than_3_chars_remains_visible() {
+        let transformer = get_transformer();
+        let column = Column::StringValue("credit_card_number".to_string(), "424".to_string());
+        let transformed_column = transformer.transform(column);
+        let transformed_value = transformed_column.string_value().unwrap();
+        assert_eq!(transformed_value.to_owned(), "424")
+    }
+
     fn get_transformer() -> RedactedTransformer {
         RedactedTransformer::new("github", "users", "credit_card_number")
     }

--- a/replibyte/src/transformer/redacted.rs
+++ b/replibyte/src/transformer/redacted.rs
@@ -1,0 +1,92 @@
+use crate::transformer::Transformer;
+use crate::types::Column;
+
+/// This struct is dedicated to redact a string with a specific character (default to '*').
+pub struct RedactedTransformer {
+    database_name: String,
+    table_name: String,
+    column_name: String,
+}
+
+impl RedactedTransformer {
+    pub fn new<S>(database_name: S, table_name: S, column_name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        RedactedTransformer {
+            database_name: database_name.into(),
+            table_name: table_name.into(),
+            column_name: column_name.into(),
+        }
+    }
+}
+
+impl Default for RedactedTransformer {
+    fn default() -> Self {
+        RedactedTransformer {
+            database_name: String::default(),
+            table_name: String::default(),
+            column_name: String::default(),
+        }
+    }
+}
+
+impl Transformer for RedactedTransformer {
+    fn id(&self) -> &str {
+        "redacted"
+    }
+
+    fn description(&self) -> &str {
+        "Obfuscate your sensitive data (string only). [4242 4242 4242 4242]->[424****************]"
+    }
+
+    fn database_name(&self) -> &str {
+        self.database_name.as_str()
+    }
+
+    fn table_name(&self) -> &str {
+        self.table_name.as_str()
+    }
+
+    fn column_name(&self) -> &str {
+        self.column_name.as_str()
+    }
+
+    fn transform(&self, column: Column) -> Column {
+        match column {
+            Column::StringValue(column_name, value) => {
+                let new_value = match value.len() {
+                    len if len > 3 => {
+                        format!("{}{:*<10}", &value[0..3], "*")
+                    }
+                    _ => value,
+                };
+                Column::StringValue(column_name, new_value)
+            }
+            column => column,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{transformer::Transformer, types::Column};
+
+    use super::RedactedTransformer;
+
+    #[test]
+    fn redact() {
+        let transformer = get_transformer();
+        let column = Column::StringValue(
+            "credit_card_number".to_string(),
+            "4242 4242 4242 4242".to_string(),
+        );
+        let transformed_column = transformer.transform(column);
+        let transformed_value = transformed_column.string_value().unwrap();
+        assert_eq!(transformed_value.to_owned(), "424**********")
+    }
+
+    fn get_transformer() -> RedactedTransformer {
+        RedactedTransformer::new("github", "users", "credit_card_number")
+    }
+}


### PR DESCRIPTION
@evoxmusic 
A new `redacted` transformer  (strings only), it adds 10 `*` for string longer than 3 characters. 

"a" -> "a"
"abc" -> "abc"
"abcd" -> "abc**********"
"4242 4242 4242 4242" -> "424**********"

In a future PR, we could add options to change the default "*" character, keeping the same length or the number of characters to remain visible. 

If the default behavior seems right for you, you're free to merge 

