### PR TITLE
feat: add mongo auth db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,7 +1632,7 @@ dependencies = [
  "serde_yaml",
  "timeago",
  "tokio",
- "uriparse",
+ "url",
  "which",
 ]
 
@@ -1975,6 +1986,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2141,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,13 +2184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "uriparse"
-version = "0.6.3"
+name = "url"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e515b1ada404168e145ac55afba3c42f04cf972201a8552d42e2abb17c1b7221"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
- "fnv",
- "lazy_static",
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/replibyte/Cargo.toml
+++ b/replibyte/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Qovery"]
 
 [dependencies]
 rand = "0.8.5"
-uriparse = "0.6"
 anyhow = "1.0.56"
 serde_yaml = "0.8"
 serde_json = "1.0"
@@ -34,3 +33,4 @@ flate2 = "1.0"
 bson = "2.1"
 aes-gcm = "0.9"
 which = "4.2.5"
+url = "2.2.2"

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -9,8 +9,11 @@ use crate::transformer::transient::TransientTransformer;
 use crate::transformer::Transformer;
 use serde;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
-use uriparse::URIReference;
+use url::Url;
+
+const DEFAULT_MONGODB_AUTH_DB: &str = "admin";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
@@ -236,15 +239,24 @@ type Port = u16;
 type Username = String;
 type Password = String;
 type Database = String;
+type AuthenticationDatabase = String;
 
+#[derive(Debug, PartialEq)]
 pub enum ConnectionUri {
     Postgres(Host, Port, Username, Password, Database),
     Mysql(Host, Port, Username, Password, Database),
-    MongoDB(Host, Port, Username, Password, Database),
+    MongoDB(
+        Host,
+        Port,
+        Username,
+        Password,
+        Database,
+        AuthenticationDatabase,
+    ),
 }
 
-fn get_host(uri_ref: &URIReference) -> Result<String, Error> {
-    match uri_ref.host() {
+fn get_host(url: &Url) -> Result<String, Error> {
+    match url.host() {
         Some(host) => Ok(host.to_string()),
         None => Err(Error::new(
             ErrorKind::Other,
@@ -253,8 +265,8 @@ fn get_host(uri_ref: &URIReference) -> Result<String, Error> {
     }
 }
 
-fn get_port(uri_ref: &URIReference, default_port: u16) -> Result<u16, Error> {
-    match uri_ref.port() {
+fn get_port(url: &Url, default_port: u16) -> Result<u16, Error> {
+    match url.port() {
         Some(port) if port < 1 => Err(Error::new(
             ErrorKind::Other,
             "<port> from connection uri can't be lower than 0",
@@ -264,18 +276,18 @@ fn get_port(uri_ref: &URIReference, default_port: u16) -> Result<u16, Error> {
     }
 }
 
-fn get_username(uri_ref: &URIReference) -> Result<String, Error> {
-    match uri_ref.username() {
-        Some(username) => Ok(username.to_string()),
-        None => Err(Error::new(
+fn get_username(url: &Url) -> Result<String, Error> {
+    match url.username() {
+        username if username != "" => Ok(username.to_string()),
+        _ => Err(Error::new(
             ErrorKind::Other,
             "missing <username> property from connection uri",
         )),
     }
 }
 
-fn get_password(uri_ref: &URIReference) -> Result<String, Error> {
-    match uri_ref.password() {
+fn get_password(url: &Url) -> Result<String, Error> {
+    match url.password() {
         Some(password) => Ok(password.to_string()),
         None => Err(Error::new(
             ErrorKind::Other,
@@ -284,9 +296,9 @@ fn get_password(uri_ref: &URIReference) -> Result<String, Error> {
     }
 }
 
-fn get_database(uri_ref: &URIReference, default: Option<&str>) -> Result<String, Error> {
-    let path = uri_ref.path().to_string();
-    let database = path.split("/").take(1).collect::<Vec<&str>>();
+fn get_database(url: &Url, default: Option<&str>) -> Result<String, Error> {
+    let path = url.path().to_string();
+    let database = path.split("/").collect::<Vec<&str>>();
 
     if database.is_empty() {
         return match default {
@@ -298,7 +310,7 @@ fn get_database(uri_ref: &URIReference, default: Option<&str>) -> Result<String,
         };
     }
 
-    let database = match database.get(0) {
+    let database = match database.get(1) {
         Some(database) => *database,
         None => {
             return match default {
@@ -314,49 +326,55 @@ fn get_database(uri_ref: &URIReference, default: Option<&str>) -> Result<String,
     Ok(database.to_string())
 }
 
+fn get_mongodb_authentication_db(url: &Url) -> String {
+    let hash_query: HashMap<String, String> = url.query_pairs().into_owned().collect();
+
+    let authentication_database = match hash_query.get("authSource") {
+        Some(auth_source) => auth_source.to_string(),
+        None => DEFAULT_MONGODB_AUTH_DB.to_string(),
+    };
+
+    authentication_database
+}
+
 fn parse_connection_uri(uri: &str) -> Result<ConnectionUri, Error> {
     let uri = substitute_env_var(uri)?;
 
-    let uri_ref = match URIReference::try_from(uri.as_str()) {
-        Ok(uri_ref) => uri_ref,
+    let url = match Url::parse(uri.as_str()) {
+        Ok(url) => url,
         Err(err) => return Err(Error::new(ErrorKind::Other, format!("{:?}", err))),
     };
 
-    let connection_uri = match uri_ref.scheme() {
-        Some(err) if err.as_str().to_lowercase() == "postgres" => ConnectionUri::Postgres(
-            get_host(&uri_ref)?,
-            get_port(&uri_ref, 5432)?,
-            get_username(&uri_ref)?,
-            get_password(&uri_ref)?,
-            get_database(&uri_ref, Some("public"))?,
+    let connection_uri = match url.scheme() {
+        scheme if scheme.to_lowercase() == "postgres" => ConnectionUri::Postgres(
+            get_host(&url)?,
+            get_port(&url, 5432)?,
+            get_username(&url)?,
+            get_password(&url)?,
+            get_database(&url, Some("public"))?,
         ),
-        Some(err) if err.as_str().to_lowercase() == "mysql" => ConnectionUri::Postgres(
-            get_host(&uri_ref)?,
-            get_port(&uri_ref, 3306)?,
-            get_username(&uri_ref)?,
-            get_password(&uri_ref)?,
-            get_database(&uri_ref, None)?,
+        scheme if scheme.to_lowercase() == "mysql" => ConnectionUri::Postgres(
+            get_host(&url)?,
+            get_port(&url, 3306)?,
+            get_username(&url)?,
+            get_password(&url)?,
+            get_database(&url, None)?,
         ),
-        Some(err)
-            if err.as_str().to_lowercase() == "mongodb"
-                || err.as_str().to_lowercase() == "mongodb+srv" =>
-        {
+        scheme if scheme.to_lowercase() == "mongodb" || scheme.to_lowercase() == "mongodb+srv" => {
             ConnectionUri::MongoDB(
-                get_host(&uri_ref)?,
-                get_port(&uri_ref, 27017)?,
-                get_username(&uri_ref)?,
-                get_password(&uri_ref)?,
-                get_database(&uri_ref, None)?,
+                get_host(&url)?,
+                get_port(&url, 27017)?,
+                get_username(&url)?,
+                get_password(&url)?,
+                get_database(&url, Some(DEFAULT_MONGODB_AUTH_DB))?,
+                get_mongodb_authentication_db(&url),
             )
         }
-        Some(err) => {
+        scheme => {
             return Err(Error::new(
                 ErrorKind::Other,
-                format!("'{}' not supported", err.as_str()),
+                format!("'{}' not supported", scheme),
             ));
-        }
-        None => {
-            return Err(Error::new(ErrorKind::Other, "missing URI scheme"));
         }
     };
 
@@ -392,7 +410,7 @@ fn substitute_env_var(env_var: &str) -> Result<String, Error> {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{parse_connection_uri, substitute_env_var};
+    use crate::config::{parse_connection_uri, substitute_env_var, ConnectionUri};
 
     #[test]
     fn substitute_env_variables() {
@@ -409,17 +427,52 @@ mod tests {
 
     #[test]
     fn parse_postgres_connection_uri() {
-        assert!(parse_connection_uri("postgres://root:password@localhost:5432/root").is_ok());
+        assert!(parse_connection_uri("postgres://root:password@localhost:5432/db").is_ok());
         assert!(parse_connection_uri("postgres://root:password@localhost:5432").is_ok());
         assert!(parse_connection_uri("postgres://root:password@localhost").is_ok());
         assert!(parse_connection_uri("postgres://root:password").is_err());
     }
+
+    #[test]
+    fn parse_postgres_connection_uri_with_db() {
+        assert_eq!(
+            parse_connection_uri("postgres://root:password@localhost:5432/db").unwrap(),
+            ConnectionUri::Postgres(
+                "localhost".to_string(),
+                5432,
+                "root".to_string(),
+                "password".to_string(),
+                "db".to_string()
+            ),
+        )
+    }
+
     #[test]
     fn parse_mongodb_connection_uri() {
-        assert!(parse_connection_uri("mongodb://root:password@localhost:27017/root").is_ok());
+        assert!(parse_connection_uri("mongodb://root:password").is_err());
         assert!(parse_connection_uri("mongodb://root:password@localhost:27017").is_ok());
+        assert!(parse_connection_uri("mongodb://root:password@localhost:27017/db").is_ok());
         assert!(parse_connection_uri("mongodb://root:password@localhost").is_ok());
         assert!(parse_connection_uri("mongodb+srv://root:password@server.example.com/").is_ok());
-        assert!(parse_connection_uri("mongodb://root:password").is_err());
+    }
+
+    #[test]
+    fn parse_mongodb_connection_uri_with_db() {
+        let connection_uri = parse_connection_uri(
+            "mongodb+srv://root:password@server.example.com/my_db?authSource=other_db",
+        )
+        .unwrap();
+
+        assert_eq!(
+            connection_uri,
+            ConnectionUri::MongoDB(
+                "server.example.com".to_string(),
+                27017,
+                "root".to_string(),
+                "password".to_string(),
+                "my_db".to_string(),
+                "other_db".to_string(),
+            )
+        )
     }
 }

--- a/replibyte/src/destination/mongodb.rs
+++ b/replibyte/src/destination/mongodb.rs
@@ -41,41 +41,7 @@ impl<'a> Connector for MongoDB<'a> {
     fn init(&mut self) -> Result<(), Error> {
         let _ = binary_exists("mongo")?;
         let _ = binary_exists("mongorestore")?;
-
-        let s_port = self.port.to_string();
-
-        let mut echo_process = Command::new("echo")
-            .arg(r#"'db.runCommand("ping").ok'"#)
-            .stdout(Stdio::piped())
-            .spawn()?;
-
-        let args = vec![
-            "--host",
-            self.host,
-            "--port",
-            s_port.as_str(),
-            "--authenticationDatabase",
-            self.authentication_database,
-            "-u",
-            self.username,
-            "-p",
-            self.password,
-            "--quiet",
-        ];
-
-        let mut mongo_process = Command::new("mongo")
-            .args(args)
-            .stdin(echo_process.stdout.take().unwrap())
-            .stdout(Stdio::null())
-            .spawn()?;
-
-        let exit_status = mongo_process.wait()?;
-        if !exit_status.success() {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!("command error: {:?}", exit_status.to_string()),
-            ));
-        }
+        let _ = check_connection_status(self)?;
 
         Ok(())
     }
@@ -121,6 +87,43 @@ impl<'a> Destination for MongoDB<'a> {
 
         Ok(())
     }
+}
+
+fn check_connection_status(db: &MongoDB) -> Result<(), Error> {
+    let s_port = db.port.to_string();
+
+    let mut echo_process = Command::new("echo")
+        .arg(r#"'db.runCommand("ping").ok'"#)
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    let mut mongo_process = Command::new("mongo")
+        .args([
+            "--host",
+            db.host,
+            "--port",
+            s_port.as_str(),
+            "--authenticationDatabase",
+            db.authentication_database,
+            "-u",
+            db.username,
+            "-p",
+            db.password,
+            "--quiet",
+        ])
+        .stdin(echo_process.stdout.take().unwrap())
+        .stdout(Stdio::inherit())
+        .spawn()?;
+
+    let exit_status = mongo_process.wait()?;
+    if !exit_status.success() {
+        return Err(Error::new(
+            ErrorKind::Other,
+            format!("command error: {:?}", exit_status.to_string()),
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/replibyte/src/main.rs
+++ b/replibyte/src/main.rs
@@ -224,13 +224,21 @@ fn main() -> anyhow::Result<()> {
                             ConnectionUri::Mysql(host, port, username, password, database) => {
                                 todo!() // FIXME
                             }
-                            ConnectionUri::MongoDB(host, port, username, password, database) => {
+                            ConnectionUri::MongoDB(
+                                host,
+                                port,
+                                username,
+                                password,
+                                database,
+                                authentication_db,
+                            ) => {
                                 let mongodb = SourceMongoDB::new(
                                     host.as_str(),
                                     port,
                                     database.as_str(),
                                     username.as_str(),
                                     password.as_str(),
+                                    authentication_db.as_str(),
                                 );
 
                                 let task = FullBackupTask::new(mongodb, bridge, options);
@@ -306,13 +314,21 @@ fn main() -> anyhow::Result<()> {
                     ConnectionUri::Mysql(host, port, username, password, database) => {
                         todo!() // FIXME
                     }
-                    ConnectionUri::MongoDB(host, port, username, password, database) => {
+                    ConnectionUri::MongoDB(
+                        host,
+                        port,
+                        username,
+                        password,
+                        database,
+                        authentication_db,
+                    ) => {
                         let mongodb = DestinationMongoDB::new(
                             host.as_str(),
                             port,
                             database.as_str(),
                             username.as_str(),
                             password.as_str(),
+                            authentication_db.as_str(),
                         );
 
                         let task = FullRestoreTask::new(mongodb, bridge, options);

--- a/replibyte/src/source/mongodb.rs
+++ b/replibyte/src/source/mongodb.rs
@@ -18,6 +18,7 @@ pub struct MongoDB<'a> {
     database: &'a str,
     username: &'a str,
     password: &'a str,
+    authentication_database: &'a str,
 }
 
 impl<'a> MongoDB<'a> {
@@ -27,6 +28,7 @@ impl<'a> MongoDB<'a> {
         database: &'a str,
         username: &'a str,
         password: &'a str,
+        authentication_database: &'a str,
     ) -> Self {
         MongoDB {
             host,
@@ -34,6 +36,7 @@ impl<'a> MongoDB<'a> {
             database,
             username,
             password,
+            authentication_database,
         }
     }
 }
@@ -61,7 +64,7 @@ impl<'a> Source for MongoDB<'a> {
                 "--port",
                 s_port.as_str(),
                 "--authenticationDatabase",
-                "admin",
+                self.authentication_database,
                 "--db",
                 self.database,
                 "-u",
@@ -290,11 +293,11 @@ mod tests {
     use super::recursively_transform_document;
 
     fn get_mongodb() -> MongoDB<'static> {
-        MongoDB::new("localhost", 27017, "test", "root", "password")
+        MongoDB::new("localhost", 27017, "test", "root", "password", "admin")
     }
 
     fn get_invalid_mongodb() -> MongoDB<'static> {
-        MongoDB::new("localhost", 27017, "test", "root", "wrongpassword")
+        MongoDB::new("localhost", 27017, "test", "root", "wrongpassword", "admin")
     }
 
     #[test]


### PR DESCRIPTION
Hi @evoxmusic 
This PR add support for the authSource parameter in mongo connection string. It was set as "admin" during `mongodump` and `mongorestore` commands.  The default remains the `admin` database as it's the default in MongoDB.
Later we could still improve by supporting other options as tls, ... in connection uri for Mongo and Postgres.

I also add a connection status check in the source init. (the same as in the destination init)

Before:

```
➜  replibyte git:(add-mongo-auth-db) ✗ 2022-04-02T15:59:50.181+0200	Failed: I/O failure reading beginning of archive: EOF
2022-04-02T15:59:50.181+0200	0 document(s) restored successfully. 0 document(s) failed to restore.
```

Now:

```
➜  replibyte git:(add-mongo-auth-db) ✗ ./target/debug/replibyte -c ./examples/source-and-dest-mongodb-bridge-minio.yaml backup run
⠋
Error: Authentication failed. :
connect@src/mongo/shell/mongo.js:372:17
@(connect):3:6
exception: connect failed
exiting with code 1
Error: command error: "exit status: 1"
```

It helps a little for troubleshooting connection string issues.