### PR TITLE
fix: print correct connection string when restoring in a local Postgres container

### DIFF
--- a/replibyte/src/destination/postgres_docker.rs
+++ b/replibyte/src/destination/postgres_docker.rs
@@ -10,9 +10,9 @@ use std::io::{Error, ErrorKind, Write};
 const DEFAULT_POSTGRES_IMAGE: &str = "postgres";
 pub const DEFAULT_POSTGRES_IMAGE_TAG: &str = "13";
 pub const DEFAULT_POSTGRES_CONTAINER_PORT: u16 = 5432;
-const DEFAULT_POSTGRES_USER: &str = "postgres";
-const DEFAULT_POSTGRES_PASSWORD: &str = "password";
-const DEFAULT_POSTGRES_DB: &str = "postgres";
+pub const DEFAULT_POSTGRES_USER: &str = "postgres";
+pub const DEFAULT_POSTGRES_PASSWORD: &str = "password";
+pub const DEFAULT_POSTGRES_DB: &str = "postgres";
 
 pub struct PostgresDocker {
     pub image: Image,

--- a/replibyte/src/main.rs
+++ b/replibyte/src/main.rs
@@ -27,7 +27,8 @@ use crate::destination::mongodb_docker::{
 };
 use crate::destination::postgres::Postgres as DestinationPostgres;
 use crate::destination::postgres_docker::{
-    PostgresDocker, DEFAULT_POSTGRES_CONTAINER_PORT, DEFAULT_POSTGRES_IMAGE_TAG,
+    PostgresDocker, DEFAULT_POSTGRES_CONTAINER_PORT, DEFAULT_POSTGRES_DB,
+    DEFAULT_POSTGRES_IMAGE_TAG, DEFAULT_POSTGRES_PASSWORD, DEFAULT_POSTGRES_USER,
 };
 use crate::destination::postgres_stdout::PostgresStdout;
 use crate::source::mongodb::MongoDB as SourceMongoDB;
@@ -322,7 +323,13 @@ fn main() -> anyhow::Result<()> {
                         let _ = task.run(progress_callback)?;
 
                         println!("To connect to your Postgres database, use the following connection string:");
-                        println!("> postgres://root:password@localhost:{}/root", port);
+                        println!(
+                            "> postgres://{}:{}@localhost:{}/{}",
+                            DEFAULT_POSTGRES_USER,
+                            DEFAULT_POSTGRES_PASSWORD,
+                            port,
+                            DEFAULT_POSTGRES_DB
+                        );
                         wait_until_ctrlc("Waiting for Ctrl-C to stop the container");
 
                         match postgres.container {


### PR DESCRIPTION
Wrong credentials was printed when the container was starting. Let me know if it works for you now @evoxmusic 


This is the corrected command output:
```sh
cargo run -- -c ./examples/source-postgres-bridge-minio.yaml restore local -v latest --image postgres --port 5433

To connect to your Postgres database, use the following connection string:
> postgres://postgres:password@localhost:5433/postgres
Waiting for Ctrl-C to stop the container
```


```sh
PGPASSWORD=password psql -h localhost -p 5433 -U postgres -d postgres
psql (14.2, server 13beta3 (Debian 13~beta3-1.pgdg100+1))
Type "help" for help.

postgres=# \dt+
                                              List of relations
 Schema |          Name          | Type  |  Owner   | Persistence | Access method |    Size    | Description
--------+------------------------+-------+----------+-------------+---------------+------------+-------------
 public | categories             | table | postgres | permanent   | heap          | 16 kB      |
 public | customer_customer_demo | table | postgres | permanent   | heap          | 8192 bytes |
 public | customer_demographics  | table | postgres | permanent   | heap          | 8192 bytes |
 public | customers              | table | postgres | permanent   | heap          | 48 kB      |
 public | employee_territories   | table | postgres | permanent   | heap          | 8192 bytes |
 public | employees              | table | postgres | permanent   | heap          | 16 kB      |
 public | order_details          | table | postgres | permanent   | heap          | 120 kB     |
 public | orders                 | table | postgres | permanent   | heap          | 144 kB     |
 public | products               | table | postgres | permanent   | heap          | 8192 bytes |
 public | region                 | table | postgres | permanent   | heap          | 16 kB      |
 public | shippers               | table | postgres | permanent   | heap          | 8192 bytes |
 public | suppliers              | table | postgres | permanent   | heap          | 16 kB      |
 public | territories            | table | postgres | permanent   | heap          | 16 kB      |
 public | us_states              | table | postgres | permanent   | heap          | 8192 bytes |
(14 rows)
```

Closes #48 