### PR TITLE
fix: cli parsing for compression and encryption parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ replibyte -c prod-conf.yaml restore remote -v backup-1647706359405
 Create your `prod-conf.yaml` configuration file to source your production database.
 
 ```yaml
+encryption_key: $MY_PRIVATE_ENC_KEY # optional - encrypt data on bridge
 source:
   connection_uri: $DATABASE_URL
-  encryption_key: $MY_PRIVATE_ENC_KEY # optional - encrypt data on bridge
   database_subset: # optional - downscale database while keeping it consistent
     database: public
     table: orders
@@ -271,7 +271,7 @@ bridge:
   secret_access_key: $AWS_SECRET_ACCESS_KEY
 destination:
   connection_uri: $DATABASE_URL
-  decryption_key: $MY_PUBLIC_DEC_KEY # optional
+encryption_key: $MY_PRIVATE_ENC_KEY # optional - needed to decrypt data on bridge if there was an encryption_key defined when running the source backup
 ```
 
 Run the app for the destination

--- a/examples/replibyte.yaml
+++ b/examples/replibyte.yaml
@@ -11,7 +11,6 @@ source:
           transformer_name: random # TO CHANGE
 destination:
   connection_uri: $DESTINATION_CONNECTION_URI
-  encryption_key: $ENCRYPTION_SECRET
 bridge:
   bucket: $S3_BUCKET
   region: $S3_REGION

--- a/examples/replibyte.yaml
+++ b/examples/replibyte.yaml
@@ -1,6 +1,6 @@
+encryption_key: $ENCRYPTION_SECRET
 source:
   connection_uri: $SOURCE_CONNECTION_URI
-  encryption_key: $ENCRYPTION_SECRET
   transformers:
     - database: public # TO CHANGE
       table: employees # TO CHANGE

--- a/examples/source-postgres-bridge-minio.yaml
+++ b/examples/source-postgres-bridge-minio.yaml
@@ -1,3 +1,4 @@
+encryption_key: 'this is a test'
 source:
   connection_uri: postgres://root:password@localhost:5432/root
   transformers:
@@ -15,3 +16,5 @@ bridge:
   secret_access_key: minioadmin
   endpoint:
     custom: 'http://localhost:9000'
+destination:
+  connection_uri: postgres://root:password@localhost:5453/root

--- a/examples/with-encryption.yaml
+++ b/examples/with-encryption.yaml
@@ -1,6 +1,6 @@
+encryption_key: this is a secret key
 source:
   connection_uri: postgres://root:password@localhost:5432/root
-  encryption_key: this is a secret key
   transformers:
     - database: public
       table: employees

--- a/examples/with-encryption.yaml
+++ b/examples/with-encryption.yaml
@@ -12,7 +12,6 @@ source:
 destination:
   # it's different to the source
   connection_uri: postgres://root:password@localhost:5453/root
-  encryption_key: this is a secret key
 bridge:
   bucket: replibyte-test
   region: us-east-2

--- a/replibyte/src/bridge/mod.rs
+++ b/replibyte/src/bridge/mod.rs
@@ -21,7 +21,7 @@ pub trait Bridge: Connector + Send + Sync {
     where
         F: FnMut(Bytes);
     fn set_compression(&mut self, enable: bool);
-    fn set_encryption_key(&mut self, key: Option<String>);
+    fn set_encryption_key(&mut self, key: String);
 }
 
 #[derive(Serialize, Deserialize)]

--- a/replibyte/src/commands/backup.rs
+++ b/replibyte/src/commands/backup.rs
@@ -63,14 +63,14 @@ where
     F: Fn(usize, usize) -> (),
     B: Bridge + 'static,
 {
+    if let Some(encryption_key) = config.encryption_key()? {
+        bridge.set_encryption_key(encryption_key)
+    }
+
     match config.source {
         Some(source) => {
             // Configure bridge options (compression is enabled by default)
             bridge.set_compression(source.compression.unwrap_or(true));
-
-            if let Some(encryption_key) = source.encryption_key()? {
-                bridge.set_encryption_key(encryption_key)
-            }
 
             // Match the transformers from the config
             let transformers = source

--- a/replibyte/src/commands/backup.rs
+++ b/replibyte/src/commands/backup.rs
@@ -53,14 +53,25 @@ pub fn list(s3: &mut S3) -> Result<(), Error> {
 }
 
 // Run a new backup
-pub fn run<F: Fn(usize, usize) -> (), B: Bridge + 'static>(
+pub fn run<F, B>(
     args: &BackupRunArgs,
-    bridge: B,
+    mut bridge: B,
     config: Config,
     progress_callback: F,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    F: Fn(usize, usize) -> (),
+    B: Bridge + 'static,
+{
     match config.source {
         Some(source) => {
+            // Configure bridge options (compression is enabled by default)
+            bridge.set_compression(source.compression.unwrap_or(true));
+
+            if let Some(encryption_key) = source.encryption_key()? {
+                bridge.set_encryption_key(encryption_key)
+            }
+
             // Match the transformers from the config
             let transformers = source
                 .transformers

--- a/replibyte/src/commands/restore.rs
+++ b/replibyte/src/commands/restore.rs
@@ -31,11 +31,8 @@ where
     F: Fn(usize, usize) -> (),
     B: Bridge + 'static,
 {
-    // The encryption key is necessarily the same as the source configuration so we read it in the source configuration
-    if let Some(source_config) = config.source {
-        if let Some(encryption_key) = source_config.encryption_key()? {
-            bridge.set_encryption_key(encryption_key);
-        }
+    if let Some(encryption_key) = config.encryption_key()? {
+        bridge.set_encryption_key(encryption_key);
     }
 
     let options = match args.value.as_str() {
@@ -197,11 +194,8 @@ where
     F: Fn(usize, usize) -> (),
     B: Bridge + 'static,
 {
-    // The encryption key is necessarily the same as the source configuration so we read it in the source configuration
-    if let Some(source_config) = config.source {
-        if let Some(encryption_key) = source_config.encryption_key()? {
-            bridge.set_encryption_key(encryption_key);
-        }
+    if let Some(encryption_key) = config.encryption_key()? {
+        bridge.set_encryption_key(encryption_key);
     }
 
     match config.destination {

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -121,20 +121,11 @@ impl SourceConfig {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct DestinationConfig {
     pub connection_uri: String,
-    pub compression: Option<bool>,
-    pub encryption_key: Option<String>,
 }
 
 impl DestinationConfig {
     pub fn connection_uri(&self) -> Result<ConnectionUri, Error> {
         parse_connection_uri(self.connection_uri.as_str())
-    }
-
-    pub fn encryption_key(&self) -> Result<Option<String>, Error> {
-        match &self.encryption_key {
-            Some(key) => substitute_env_var(key.as_str()).map(|x| Some(x)),
-            None => Ok(None),
-        }
     }
 }
 

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub source: Option<SourceConfig>,
     pub bridge: BridgeConfig,
     pub destination: Option<DestinationConfig>,
+    pub encryption_key: Option<String>,
 }
 
 pub enum ConnectorConfig<'a> {
@@ -44,6 +45,13 @@ impl Config {
             ErrorKind::Other,
             "<source> or <destination> is mandatory",
         ))
+    }
+
+    pub fn encryption_key(&self) -> Result<Option<String>, Error> {
+        match &self.encryption_key {
+            Some(key) => substitute_env_var(key.as_str()).map(|x| Some(x)),
+            None => Ok(None),
+        }
     }
 }
 
@@ -99,7 +107,6 @@ impl BridgeConfig {
 pub struct SourceConfig {
     pub connection_uri: String,
     pub compression: Option<bool>,
-    pub encryption_key: Option<String>,
     pub transformers: Vec<TransformerConfig>,
     pub skip: Option<Vec<SkipConfig>>,
     pub database_subset: Option<DatabaseSubsetConfig>,
@@ -108,13 +115,6 @@ pub struct SourceConfig {
 impl SourceConfig {
     pub fn connection_uri(&self) -> Result<ConnectionUri, Error> {
         parse_connection_uri(self.connection_uri.as_str())
-    }
-
-    pub fn encryption_key(&self) -> Result<Option<String>, Error> {
-        match &self.encryption_key {
-            Some(key) => substitute_env_var(key.as_str()).map(|x| Some(x)),
-            None => Ok(None),
-        }
     }
 }
 

--- a/replibyte/src/main.rs
+++ b/replibyte/src/main.rs
@@ -94,22 +94,6 @@ fn main() -> anyhow::Result<()> {
         config.bridge.endpoint()?,
     );
 
-    match &config.source {
-        Some(source) => {
-            bridge.set_compression(source.compression.unwrap_or(true));
-            bridge.set_encryption_key(source.encryption_key()?)
-        }
-        None => {}
-    }
-
-    match &config.destination {
-        Some(dest) => {
-            bridge.set_compression(dest.compression.unwrap_or(true));
-            bridge.set_encryption_key(dest.encryption_key()?);
-        }
-        None => {}
-    }
-
     let (tx_pb, rx_pb) = mpsc::sync_channel::<(TransferredBytes, MaxBytes)>(1000);
     let sub_commands: &SubCommand = &args.sub_commands;
 
@@ -152,7 +136,7 @@ fn main() -> anyhow::Result<()> {
         },
         SubCommand::Restore(cmd) => match cmd {
             RestoreCommand::Local(args) => {
-                commands::restore::local(args, bridge, progress_callback)
+                commands::restore::local(args, bridge, config, progress_callback)
             }
             RestoreCommand::Remote(args) => {
                 commands::restore::remote(args, bridge, config, progress_callback)

--- a/replibyte/src/telemetry.rs
+++ b/replibyte/src/telemetry.rs
@@ -75,6 +75,11 @@ impl TelemetryClient {
         let mut props = HashMap::new();
         let _ = props.insert("args".to_string(), args.join(" ").to_string());
 
+        props.insert(
+            "encryption_used".to_string(),
+            config.encryption_key.is_some().to_string(),
+        );
+
         match &config.source {
             Some(x) => {
                 props.insert(
@@ -90,11 +95,6 @@ impl TelemetryClient {
                 props.insert(
                     "compression_used".to_string(),
                     x.compression.unwrap_or(true).to_string(),
-                );
-
-                props.insert(
-                    "encryption_used".to_string(),
-                    x.encryption_key.is_some().to_string(),
                 );
 
                 props.insert("skip_tables_used".to_string(), x.skip.is_some().to_string());


### PR DESCRIPTION
This PR closes #53

Compression and encryption was always override by the `destination` section in the config file. https://github.com/Qovery/replibyte/compare/main...fabriceclementz:fix-encryption?expand=1#diff-70dba71af950fe9043b343b216d6e7d1a9e8b1c85b06bbc8b060aad5111e887fL86

For the restore commands, it makes sense to check if the backup is compressed and encrypted directly from the backup manifest and not from the config file. This PR removes the encryption_key and compression option in the destination config.

The encryption key is always read from the source configuration. As the encryption key needs to be the same when encrypting or decrypting, we could add the encryption_key at the top level of the yaml file too ? WDYT @evoxmusic 

