### PR TITLE
feat: add an option to name the backup

### DIFF
--- a/replibyte/src/bridge/mod.rs
+++ b/replibyte/src/bridge/mod.rs
@@ -22,6 +22,7 @@ pub trait Bridge: Connector + Send + Sync {
         F: FnMut(Bytes);
     fn set_compression(&mut self, enable: bool);
     fn set_encryption_key(&mut self, key: String);
+    fn set_backup_name(&mut self, key: String);
 }
 
 #[derive(Serialize, Deserialize)]

--- a/replibyte/src/bridge/s3.rs
+++ b/replibyte/src/bridge/s3.rs
@@ -208,6 +208,10 @@ impl Bridge for S3 {
     fn set_compression(&mut self, enable: bool) {
         self.enable_compression = enable;
     }
+
+    fn set_backup_name(&mut self, name: String) {
+        self.root_key = name;
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -555,5 +559,15 @@ mod tests {
         assert_eq!(s3.index_file().unwrap().backups.len(), 1);
 
         assert!(delete_bucket(&s3.client, bucket.as_str(), true).is_ok());
+    }
+
+    #[test]
+    fn test_backup_name() {
+        let bucket = bucket();
+        let mut s3 = s3(bucket.as_str());
+
+        s3.set_backup_name("custom-backup-name".to_string());
+
+        assert_eq!(s3.root_key, "custom-backup-name".to_string())
     }
 }

--- a/replibyte/src/cli.rs
+++ b/replibyte/src/cli.rs
@@ -102,4 +102,7 @@ pub struct BackupRunArgs {
     #[clap(short, long, parse(from_os_str), value_name = "dump file")]
     /// dump file
     pub file: Option<PathBuf>,
+    /// backup name
+    #[clap(short, long)]
+    pub name: Option<String>,
 }

--- a/replibyte/src/main.rs
+++ b/replibyte/src/main.rs
@@ -142,6 +142,10 @@ fn run(config: Config, sub_commands: &SubCommand) -> anyhow::Result<()> {
                 Ok(())
             }
             BackupCommand::Run(args) => {
+                if let Some(name) = &args.name {
+                    bridge.set_backup_name(name.to_string());
+                }
+
                 commands::backup::run(args, bridge, config, progress_callback)
             }
         },


### PR DESCRIPTION
Hi @evoxmusic 
This PR adds a `--name` option to the `backup run` command as we discuss in #67.

Close #67 