### PR TITLE
fix: add error handling for backup run command

### DIFF
--- a/replibyte/src/destination/postgres.rs
+++ b/replibyte/src/destination/postgres.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 use crate::connector::Connector;
 use crate::destination::Destination;
 use crate::types::Bytes;
-use crate::utils::binary_exists;
+use crate::utils::{binary_exists, wait_for_command};
 
 pub struct Postgres<'a> {
     host: &'a str,
@@ -95,15 +95,7 @@ impl<'a> Destination for Postgres<'a> {
 
         let _ = process.stdin.take().unwrap().write_all(data.as_slice());
 
-        let exit_status = process.wait()?;
-        if !exit_status.success() {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!("command error: {:?}", exit_status.to_string()),
-            ));
-        }
-
-        Ok(())
+        wait_for_command(&mut process)
     }
 }
 

--- a/replibyte/src/source/mod.rs
+++ b/replibyte/src/source/mod.rs
@@ -1,4 +1,5 @@
-use std::io::Error;
+use std::io::{Error, ErrorKind, Read};
+use std::process::Child;
 
 use crate::config::{DatabaseSubsetConfig, SkipConfig};
 use crate::connector::Connector;

--- a/replibyte/src/source/mongodb.rs
+++ b/replibyte/src/source/mongodb.rs
@@ -6,7 +6,7 @@ use crate::connector::Connector;
 use crate::source::Source;
 use crate::transformer::Transformer;
 use crate::types::{Column, OriginalQuery, Query};
-use crate::utils::binary_exists;
+use crate::utils::{binary_exists, wait_for_command};
 use crate::SourceOptions;
 
 use bson::{Bson, Document};
@@ -91,35 +91,7 @@ impl<'a> Source for MongoDB<'a> {
 
         read_and_transform(reader, options, query_callback)?;
 
-        match process.wait() {
-            Ok(exit_status) => {
-                if !exit_status.success() {
-                    if let Some(stderr) = process.stderr.take().as_mut() {
-                        let mut buffer = String::new();
-                        let error = match stderr.read_to_string(&mut buffer) {
-                            Ok(_) => Error::new(ErrorKind::Other, format!("{}", buffer)),
-                            Err(err) => Error::new(ErrorKind::Other, format!("{}", err)),
-                        };
-
-                        return Err(Error::new(
-                            ErrorKind::Other,
-                            format!("command error: {}", error),
-                        ));
-                    }
-
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        format!("command error: {}", exit_status.to_string()),
-                    ));
-                }
-
-                Ok(())
-            }
-            Err(err) => Err(Error::new(
-                ErrorKind::Other,
-                format!("command error: {}", err),
-            )),
-        }
+        wait_for_command(&mut process)
     }
 }
 

--- a/replibyte/src/source/mongodb.rs
+++ b/replibyte/src/source/mongodb.rs
@@ -94,16 +94,32 @@ impl<'a> Source for MongoDB<'a> {
         match process.wait() {
             Ok(exit_status) => {
                 if !exit_status.success() {
+                    if let Some(stderr) = process.stderr.take().as_mut() {
+                        let mut buffer = String::new();
+                        let error = match stderr.read_to_string(&mut buffer) {
+                            Ok(_) => Error::new(ErrorKind::Other, format!("{}", buffer)),
+                            Err(err) => Error::new(ErrorKind::Other, format!("{}", err)),
+                        };
+
+                        return Err(Error::new(
+                            ErrorKind::Other,
+                            format!("command error: {}", error),
+                        ));
+                    }
+
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("command error: {:?}", exit_status.to_string()),
+                        format!("command error: {}", exit_status.to_string()),
                     ));
                 }
-            }
-            Err(err) => return Err(err),
-        }
 
-        Ok(())
+                Ok(())
+            }
+            Err(err) => Err(Error::new(
+                ErrorKind::Other,
+                format!("command error: {}", err),
+            )),
+        }
     }
 }
 

--- a/replibyte/src/source/mysql.rs
+++ b/replibyte/src/source/mysql.rs
@@ -15,7 +15,7 @@ use crate::connector::Connector;
 use crate::source::Source;
 use crate::transformer::Transformer;
 use crate::types::{Column, InsertIntoQuery, OriginalQuery, Query};
-use crate::utils::binary_exists;
+use crate::utils::{binary_exists, wait_for_command};
 
 use super::SourceOptions;
 
@@ -106,35 +106,7 @@ impl<'a> Source for Mysql<'a> {
 
         read_and_transform(reader, options, query_callback);
 
-        match process.wait() {
-            Ok(exit_status) => {
-                if !exit_status.success() {
-                    if let Some(stderr) = process.stderr.take().as_mut() {
-                        let mut buffer = String::new();
-                        let error = match stderr.read_to_string(&mut buffer) {
-                            Ok(_) => Error::new(ErrorKind::Other, format!("{}", buffer)),
-                            Err(err) => Error::new(ErrorKind::Other, format!("{}", err)),
-                        };
-
-                        return Err(Error::new(
-                            ErrorKind::Other,
-                            format!("command error: {}", error),
-                        ));
-                    }
-
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        format!("command error: {}", exit_status.to_string()),
-                    ));
-                }
-
-                Ok(())
-            }
-            Err(err) => Err(Error::new(
-                ErrorKind::Other,
-                format!("command error: {}", err),
-            )),
-        }
+        wait_for_command(&mut process)
     }
 }
 

--- a/replibyte/src/source/mysql.rs
+++ b/replibyte/src/source/mysql.rs
@@ -109,16 +109,32 @@ impl<'a> Source for Mysql<'a> {
         match process.wait() {
             Ok(exit_status) => {
                 if !exit_status.success() {
+                    if let Some(stderr) = process.stderr.take().as_mut() {
+                        let mut buffer = String::new();
+                        let error = match stderr.read_to_string(&mut buffer) {
+                            Ok(_) => Error::new(ErrorKind::Other, format!("{}", buffer)),
+                            Err(err) => Error::new(ErrorKind::Other, format!("{}", err)),
+                        };
+
+                        return Err(Error::new(
+                            ErrorKind::Other,
+                            format!("command error: {}", error),
+                        ));
+                    }
+
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("command error: {:?}", exit_status.to_string()),
+                        format!("command error: {}", exit_status.to_string()),
                     ));
                 }
-            }
-            Err(err) => return Err(err),
-        }
 
-        Ok(())
+                Ok(())
+            }
+            Err(err) => Err(Error::new(
+                ErrorKind::Other,
+                format!("command error: {}", err),
+            )),
+        }
     }
 }
 

--- a/replibyte/src/source/postgres.rs
+++ b/replibyte/src/source/postgres.rs
@@ -120,16 +120,32 @@ impl<'a> Source for Postgres<'a> {
         match process.wait() {
             Ok(exit_status) => {
                 if !exit_status.success() {
+                    if let Some(stderr) = process.stderr.take().as_mut() {
+                        let mut buffer = String::new();
+                        let error = match stderr.read_to_string(&mut buffer) {
+                            Ok(_) => Error::new(ErrorKind::Other, format!("{}", buffer)),
+                            Err(err) => Error::new(ErrorKind::Other, format!("{}", err)),
+                        };
+
+                        return Err(Error::new(
+                            ErrorKind::Other,
+                            format!("command error: {}", error),
+                        ));
+                    }
+
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("command error: {:?}", exit_status.to_string()),
+                        format!("command error: {}", exit_status.to_string()),
                     ));
                 }
-            }
-            Err(err) => return Err(err),
-        }
 
-        Ok(())
+                Ok(())
+            }
+            Err(err) => Err(Error::new(
+                ErrorKind::Other,
+                format!("command error: {}", err),
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Hi @evoxmusic 
To resolve #71 and give more context to RepliByte users, I've removed `panic` calls and propagates errors in the full backup task.

Then I've printed the stderr output for all the dump ("pg_dump", "mysqldump", "mongodump") commands which render like this 

```sh
replibyte -c ./examples/source-mysql-bridge-minio.yaml --no-telemetry backup run`
⠒ [00:00:00] [----------------------------------------------------------------------------------------------------------------------------------------] 0B/100.00MiB (0s)
command error: mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysqldump: Got error: 1045: Access denied for user 'root'@'172.18.0.1' (using password: YES) when trying to connect
```

Feedback welcome if you think of another solution.

I let the PR as a draft for now, maybe I should refactor a little bit by creating a function for the stderr processing.

Closes #71 