### PR TITLE
fix: make the MySQL container healthy by fixing the healthcheck command

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,18 +34,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test:
-        [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u',
-          'root',
-          '--password',
-          'password',
-        ]
+      test: ['CMD', 'mysqladmin', 'ping', '-u', 'root', '--password=password']
       timeout: 45s
       interval: 10s
       retries: 10
@@ -60,18 +49,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test:
-        [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u',
-          'root',
-          '--password',
-          'password',
-        ]
+      test: ['CMD', 'mysqladmin', 'ping', '-u', 'root', '--password=password']
       timeout: 45s
       interval: 10s
       retries: 10

--- a/docker-compose-mysql-minio.yml
+++ b/docker-compose-mysql-minio.yml
@@ -6,18 +6,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test:
-        [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u',
-          'root',
-          '--password',
-          'password',
-        ]
+      test: ['CMD', 'mysqladmin', 'ping', '-u', 'root', '--password=password']
       timeout: 45s
       interval: 10s
       retries: 10
@@ -32,18 +21,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test:
-        [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u',
-          'root',
-          '--password',
-          'password',
-        ]
+      test: ['CMD', 'mysqladmin', 'ping', '-u', 'root', '--password=password']
       timeout: 45s
       interval: 10s
       retries: 10

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -6,18 +6,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test:
-        [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u',
-          'root',
-          '--password',
-          'password',
-        ]
+      test: ['CMD', 'mysqladmin', 'ping', '-u', 'root', '--password=password']
       timeout: 45s
       interval: 10s
       retries: 10
@@ -32,18 +21,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test:
-        [
-          'CMD',
-          'mysqladmin',
-          'ping',
-          '-h',
-          'localhost',
-          '-u',
-          'root',
-          '--password',
-          'password',
-        ]
+      test: ['CMD', 'mysqladmin', 'ping', '-u', 'root', '--password=password']
       timeout: 45s
       interval: 10s
       retries: 10


### PR DESCRIPTION
Hi @evoxmusic  @benny-n 
As we discussed on Discord, this PR fix the healthcheck command for MySQL containers


```sh
> docker-compose -f "docker-compose-mysql-minio.yml" up -d

> docker ps
CONTAINER ID   IMAGE                                      COMMAND                  CREATED         STATUS                   PORTS                               NAMES
1aba86152c1c   mysql:8                                    "docker-entrypoint.s…"   4 minutes ago   Up 4 minutes (healthy)   33060/tcp, 0.0.0.0:3307->3306/tcp   replibyte_dest-mysql_1
556794c50301   minio/minio:RELEASE.2022-03-17T06-34-49Z   "/usr/bin/docker-ent…"   4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:9000-9001->9000-9001/tcp    replibyte_bridge-minio_1
3c6855bb7c07   mysql:8                                    "docker-entrypoint.s…"   4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:3306->3306/tcp, 33060/tcp   replibyte_source-mysql_1
```