### PR TITLE
fix: add a requirement to use -i and -s options in conjunction for th…

### DIFF
--- a/replibyte/src/cli.rs
+++ b/replibyte/src/cli.rs
@@ -95,11 +95,11 @@ pub struct RestoreLocalArgs {
 /// all backup run commands
 #[derive(Args, Debug)]
 pub struct DumpCreateArgs {
-    #[clap(short, long, value_name = "[postgresql | mysql | mongodb]")]
+    #[clap(name = "source_type", short, long, value_name = "[postgresql | mysql]", possible_values = &["postgresql", "mysql"], requires = "input")]
     /// database source type to import
     pub source_type: Option<String>,
     /// import dump from stdin
-    #[clap(short, long)]
+    #[clap(name = "input", short, long, requires = "source_type")]
     pub input: bool,
     #[clap(short, long, parse(from_os_str), value_name = "dump file")]
     /// dump file

--- a/website/docs/guides/1-create-a-dump.md
+++ b/website/docs/guides/1-create-a-dump.md
@@ -221,10 +221,13 @@ replibyte -c conf.yaml dump create
 <summary>Option 2 and 3: Create a transformed dump from a dump file</summary>
 
 ```shell
-cat your_dump.sql | replibyte -c conf.yaml dump create -i
+cat your_dump.sql | replibyte -c conf.yaml dump create -i -s postgresql
 ```
 
 `-i` parameter is required to read the data from the input.
+
+`-s` parameter is required if you don't have a `source.connection_uri` in the configuration file. (Valid values are `postgresql`, `postgres`, `mysql`)
+
 
 </details>
 


### PR DESCRIPTION
Hi @evoxmusic 
This PR improve the `dump create` command by adding a requirement for -i and -s options to be used in conjunction.
The documentation is updated too.

Now, I will try to address this issue https://github.com/Qovery/Replibyte/issues/98 which is a bit related.

Closes #73 