### PR TITLE
Feat: add local disk datastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ prod-conf.yaml
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/my-datastore

--- a/examples/with-local-disk-datastore.yaml
+++ b/examples/with-local-disk-datastore.yaml
@@ -1,0 +1,15 @@
+source:
+  connection_uri: postgres://root:password@localhost:5432/root
+  transformers:
+    - database: public
+      table: employees
+      columns:
+        - name: first_name
+          transformer_name: first-name
+        - name: last_name
+          transformer_name: random
+datastore:
+  local_disk:
+    dir: ./my-datastore
+destination:
+  connection_uri: postgres://root:password@localhost:5453/root

--- a/replibyte/src/cli.rs
+++ b/replibyte/src/cli.rs
@@ -4,8 +4,7 @@ use clap::{Args, Parser, Subcommand};
 
 /// Replibyte is a tool to seed your databases with your production data while keeping sensitive data safe, just pass `-h`
 #[derive(Parser, Debug)]
-#[clap(version, about, long_about = None)]
-#[clap(propagate_version = true)]
+#[clap(about, long_about = None)]
 pub struct CLI {
     /// Replibyte configuration file
     #[clap(short, long, parse(from_os_str), value_name = "configuration file")]

--- a/replibyte/src/cli.rs
+++ b/replibyte/src/cli.rs
@@ -4,7 +4,7 @@ use clap::{Args, Parser, Subcommand};
 
 /// Replibyte is a tool to seed your databases with your production data while keeping sensitive data safe, just pass `-h`
 #[derive(Parser, Debug)]
-#[clap(about, long_about = None)]
+#[clap(version, about, long_about = None)]
 #[clap(propagate_version = true)]
 pub struct CLI {
     /// Replibyte configuration file

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -61,6 +61,8 @@ pub enum DatastoreConfig {
     AWS(DatastoreAwsS3Config),
     #[serde(rename = "gcp")]
     GCP(DatastoreGcpCloudStorageConfig),
+    #[serde(rename = "local_disk")]
+    LocalDisk(DatastoreLocalDiskConfig),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -154,6 +156,18 @@ impl DatastoreGcpCloudStorageConfig {
         } else {
             Ok(Endpoint::Default)
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct DatastoreLocalDiskConfig {
+    pub dir: String,
+}
+
+impl DatastoreLocalDiskConfig {
+    /// decode and return the directory value
+    pub fn dir(&self) -> Result<String, Error> {
+        substitute_env_var(self.dir.as_str())
     }
 }
 

--- a/replibyte/src/datastore/local_disk.rs
+++ b/replibyte/src/datastore/local_disk.rs
@@ -1,0 +1,197 @@
+use std::fs::{read, read_dir, write, File, OpenOptions};
+use std::io::{BufReader, Error, Read, Write};
+
+use log::{debug, info};
+
+use crate::cli::DumpDeleteArgs;
+use crate::connector::Connector;
+use crate::types;
+use crate::utils::epoch_millis;
+
+use super::{
+    compress, decompress, decrypt, encrypt, Backup, Datastore, IndexFile, INDEX_FILE_NAME,
+};
+
+pub struct LocalDisk {
+    dir: String,
+    dump_name: String,
+    enable_compression: bool,
+    encryption_key: Option<String>,
+}
+
+impl LocalDisk {
+    pub fn new<S: Into<String>>(dir: S) -> Self {
+        Self {
+            dir: dir.into(),
+            enable_compression: true,
+            encryption_key: None,
+            dump_name: format!("dump-{}", epoch_millis()),
+        }
+    }
+
+    fn create_index_file(&self) -> Result<IndexFile, Error> {
+        // TODO: creating dir if not exists
+        match self.index_file() {
+            Ok(index_file) => Ok(index_file),
+            Err(_) => {
+                let index_file = IndexFile { backups: vec![] };
+                let _ = self.write_index_file(&index_file)?;
+                Ok(index_file)
+            }
+        }
+    }
+}
+
+impl Connector for LocalDisk {
+    fn init(&mut self) -> Result<(), Error> {
+        debug!("initializing local_disk datastore");
+        self.create_index_file().map(|_| ())
+    }
+}
+
+impl Datastore for LocalDisk {
+    fn index_file(&self) -> Result<IndexFile, Error> {
+        info!("reading index_file from datastore");
+
+        let file = OpenOptions::new()
+            .read(true)
+            .open(format!("{}/{}", self.dir, INDEX_FILE_NAME))?;
+        let reader = BufReader::new(file);
+
+        let index_file: IndexFile =
+            serde_json::from_reader(reader).map_err(|err| Error::from(err))?;
+
+        Ok(index_file)
+    }
+
+    fn write_index_file(&self, index_file: &IndexFile) -> Result<(), Error> {
+        info!("writing index_file to datastore");
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(format!("{}/{}", self.dir, INDEX_FILE_NAME))?;
+
+        serde_json::to_writer(file, index_file).map_err(|err| Error::from(err))
+    }
+
+    fn write(&self, file_part: u16, data: types::Bytes) -> Result<(), Error> {
+        // compress data?
+        let data = if self.compression_enabled() {
+            compress(data)?
+        } else {
+            data
+        };
+
+        // encrypt data?
+        let data = match self.encryption_key() {
+            Some(key) => encrypt(data, key.as_str())?,
+            None => data,
+        };
+
+        let data_size = data.len();
+        let key = format!("{}/{}.dump", self.dump_name, file_part);
+        let dir = &self.dir;
+        let destination_path = format!("{}/{}", dir, key);
+
+        let _ = write(destination_path, data)?;
+
+        // update index file
+        let mut index_file = self.index_file()?;
+
+        let mut new_backup = Backup {
+            directory_name: dir.to_string(),
+            size: 0,
+            created_at: epoch_millis(),
+            compressed: self.compression_enabled(),
+            encrypted: self.encryption_key().is_some(),
+        };
+
+        // find or create Backup
+        let mut backup = index_file
+            .backups
+            .iter_mut()
+            .find(|b| b.directory_name.as_str() == self.dump_name)
+            .unwrap_or(&mut new_backup);
+
+        if backup.size == 0 {
+            // it means it's a new backup.
+            // We need to add it into the index_file.backups
+            new_backup.size = data_size;
+            index_file.backups.push(new_backup);
+        } else {
+            // update total backup size
+            backup.size = backup.size + data_size;
+        }
+
+        // save index file
+        self.write_index_file(&index_file)
+    }
+
+    fn read(
+        &self,
+        options: &super::ReadOptions,
+        data_callback: &mut dyn FnMut(types::Bytes),
+    ) -> Result<(), Error> {
+        let mut index_file = self.index_file()?;
+        let backup = index_file.find_backup(options)?;
+        let entries = read_dir(format!("{}/{}", self.dir, backup.directory_name))?;
+
+        for entry in entries {
+            let entry = entry?;
+            let data = read(entry.path())?;
+
+            // decrypt data?
+            let data = if backup.encrypted {
+                // It should be safe to unwrap here because the backup is marked as encrypted in the backup manifest
+                // so if there is no encryption key set at the datastore level we want to panic.
+                let encryption_key = self.encryption_key.as_ref().unwrap();
+                decrypt(data, encryption_key.as_str())?
+            } else {
+                data
+            };
+
+            // decompress data?
+            let data = if backup.compressed {
+                decompress(data)?
+            } else {
+                data
+            };
+
+            data_callback(data);
+        }
+
+        Ok(())
+    }
+
+    fn compression_enabled(&self) -> bool {
+        self.enable_compression
+    }
+
+    fn set_compression(&mut self, enable: bool) {
+        if !enable {
+            info!("disable datastore compression");
+        }
+
+        self.enable_compression = enable;
+    }
+
+    fn encryption_key(&self) -> &Option<String> {
+        &self.encryption_key
+    }
+
+    fn set_encryption_key(&mut self, key: String) {
+        info!("set datastore encryption_key");
+
+        self.encryption_key = Some(key)
+    }
+
+    fn set_dump_name(&mut self, name: String) {
+        self.dump_name = name
+    }
+
+    fn delete(&self, args: &DumpDeleteArgs) -> Result<(), Error> {
+        todo!()
+    }
+}

--- a/replibyte/src/datastore/mod.rs
+++ b/replibyte/src/datastore/mod.rs
@@ -11,7 +11,10 @@ use crate::cli::DumpDeleteArgs;
 use crate::connector::Connector;
 use crate::types::Bytes;
 
+pub mod local_disk;
 pub mod s3;
+
+const INDEX_FILE_NAME: &str = "metadata.json";
 
 pub trait Datastore: Connector + Send + Sync {
     /// Getting Index file with all the backups information

--- a/replibyte/src/datastore/mod.rs
+++ b/replibyte/src/datastore/mod.rs
@@ -1,5 +1,6 @@
 use aes_gcm::aead::{Aead, NewAead};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
+use chrono::{Duration, Utc};
 use std::io::{Error, ErrorKind, Read, Write};
 
 use flate2::read::ZlibDecoder;
@@ -32,8 +33,6 @@ pub trait Datastore: Connector + Send + Sync {
     fn set_encryption_key(&mut self, key: String);
     fn set_dump_name(&mut self, name: String);
     fn delete_by_name(&self, name: String) -> Result<(), Error>;
-    fn delete_older_than(&self, days: i64) -> Result<(), Error>;
-    fn delete_keep_last(&self, keep_last: usize) -> Result<(), Error>;
 
     fn delete(&self, args: &DumpDeleteArgs) -> Result<(), Error> {
         if let Some(backup_name) = &args.dump {
@@ -74,6 +73,43 @@ pub trait Datastore: Connector + Send + Sync {
             ErrorKind::Other,
             "command error: parameters or options required",
         ))
+    }
+
+    fn delete_older_than(&self, days: i64) -> Result<(), Error> {
+        let index_file = self.index_file()?;
+
+        let threshold_date = Utc::now() - Duration::days(days);
+        let threshold_date = threshold_date.timestamp_millis() as u128;
+
+        let backups_to_delete: Vec<Backup> = index_file
+            .backups
+            .into_iter()
+            .filter(|b| b.created_at.lt(&threshold_date))
+            .collect();
+
+        for backup in backups_to_delete {
+            let dump_name = backup.directory_name;
+            self.delete_by_name(dump_name)?
+        }
+
+        Ok(())
+    }
+
+    fn delete_keep_last(&self, keep_last: usize) -> Result<(), Error> {
+        let mut index_file = self.index_file()?;
+
+        index_file
+            .backups
+            .sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        if let Some(backups) = index_file.backups.get(keep_last..) {
+            for backup in backups {
+                let dump_name = &backup.directory_name;
+                self.delete_by_name(dump_name.to_string())?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/replibyte/src/datastore/s3.rs
+++ b/replibyte/src/datastore/s3.rs
@@ -205,53 +205,61 @@ impl Datastore for S3 {
         self.root_key = name;
     }
 
-    fn delete(&self, args: &DumpDeleteArgs) -> Result<(), Error> {
-        if let Some(backup_name) = &args.dump {
-            return delete_by_name(&self, backup_name.as_str());
-        }
-
-        if let Some(older_than) = &args.older_than {
-            let days = match older_than.chars().nth_back(0) {
-                Some('d') => {
-                    // remove the last character which corresponds to the unit
-                    let mut older_than = older_than.to_string();
-                    older_than.pop();
-
-                    match older_than.parse::<i64>() {
-                        Ok(days) => days,
-                        Err(err) => return Err(Error::new(
-                            ErrorKind::Other,
-                            format!("command error: {} - invalid `--older-than` format. Use `--older-than=14d`", err),
-                        )),
-                    }
-                }
-                _ => {
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        "command error: invalid `--older-than` format. Use `--older-than=14d`",
-                    ));
-                }
-            };
-
-            return delete_older_than(&self, days);
-        }
-
-        if let Some(keep_last) = args.keep_last {
-            return delete_keep_last(&self, keep_last);
-        }
-
-        Err(Error::new(
-            ErrorKind::Other,
-            "command error: parameters or options required",
-        ))
-    }
-
     fn compression_enabled(&self) -> bool {
         self.enable_compression
     }
 
     fn encryption_key(&self) -> &Option<String> {
         &self.encryption_key
+    }
+
+    fn delete_by_name(&self, name: String) -> Result<(), Error> {
+        let mut index_file = self.index_file()?;
+
+        let bucket = &self.bucket;
+
+        let _ = delete_directory(&self.client, bucket, &name).map_err(|err| Error::from(err))?;
+
+        index_file.backups.retain(|b| b.directory_name != name);
+
+        self.write_index_file(&index_file)
+    }
+
+    fn delete_older_than(&self, days: i64) -> Result<(), Error> {
+        let index_file = self.index_file()?;
+
+        let threshold_date = Utc::now() - Duration::days(days);
+        let threshold_date = threshold_date.timestamp_millis() as u128;
+
+        let backups_to_delete: Vec<Backup> = index_file
+            .backups
+            .into_iter()
+            .filter(|b| b.created_at.lt(&threshold_date))
+            .collect();
+
+        for backup in backups_to_delete {
+            let dump_name = backup.directory_name;
+            self.delete_by_name(dump_name)?
+        }
+
+        Ok(())
+    }
+
+    fn delete_keep_last(&self, keep_last: usize) -> Result<(), Error> {
+        let mut index_file = self.index_file()?;
+
+        index_file
+            .backups
+            .sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        if let Some(backups) = index_file.backups.get(keep_last..) {
+            for backup in backups {
+                let dump_name = &backup.directory_name;
+                self.delete_by_name(dump_name.to_string())?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -312,56 +320,6 @@ fn write_objects<B: Datastore>(
     }
 
     // save index file
-    datastore.write_index_file(&index_file)
-}
-
-fn delete_older_than(datastore: &S3, days: i64) -> Result<(), Error> {
-    let index_file = datastore.index_file()?;
-
-    let threshold_date = Utc::now() - Duration::days(days);
-    let threshold_date = threshold_date.timestamp_millis() as u128;
-
-    let backups_to_delete: Vec<Backup> = index_file
-        .backups
-        .into_iter()
-        .filter(|b| b.created_at.lt(&threshold_date))
-        .collect();
-
-    for backup in backups_to_delete {
-        delete_by_name(&datastore, backup.directory_name.as_str())?
-    }
-
-    Ok(())
-}
-
-fn delete_keep_last(datastore: &S3, keep_last: usize) -> Result<(), Error> {
-    let mut index_file = datastore.index_file()?;
-
-    index_file
-        .backups
-        .sort_by(|a, b| b.created_at.cmp(&a.created_at));
-
-    if let Some(backups) = index_file.backups.get(keep_last..) {
-        for backup in backups {
-            delete_by_name(&datastore, backup.directory_name.as_str())?;
-        }
-    }
-
-    Ok(())
-}
-
-fn delete_by_name(datastore: &S3, backup_name: &str) -> Result<(), Error> {
-    let mut index_file = datastore.index_file()?;
-
-    let bucket = &datastore.bucket;
-
-    let _ =
-        delete_directory(&datastore.client, bucket, backup_name).map_err(|err| Error::from(err))?;
-
-    index_file
-        .backups
-        .retain(|b| b.directory_name != backup_name);
-
     datastore.write_index_file(&index_file)
 }
 

--- a/replibyte/src/datastore/s3.rs
+++ b/replibyte/src/datastore/s3.rs
@@ -22,7 +22,8 @@ use crate::runtime::block_on;
 use crate::types::Bytes;
 use crate::utils::epoch_millis;
 
-const INDEX_FILE_NAME: &str = "metadata.json";
+use super::INDEX_FILE_NAME;
+
 const GOOGLE_CLOUD_STORAGE_URL: &str = "https://storage.googleapis.com";
 
 pub struct S3 {

--- a/replibyte/src/main.rs
+++ b/replibyte/src/main.rs
@@ -13,6 +13,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::cli::{DumpCommand, RestoreCommand, SubCommand, TransformerCommand, CLI};
 use crate::config::{Config, DatabaseSubsetConfig, DatastoreConfig};
+use crate::datastore::local_disk::LocalDisk;
 use crate::datastore::s3::S3;
 use crate::datastore::Datastore;
 use crate::source::{Source, SourceOptions};
@@ -125,6 +126,7 @@ fn run(config: Config, sub_commands: &SubCommand) -> anyhow::Result<()> {
             config.secret()?,
             config.endpoint()?,
         )),
+        DatastoreConfig::LocalDisk(config) => Box::new(LocalDisk::new(config.dir()?)),
     };
 
     let (tx_pb, rx_pb) = mpsc::sync_channel::<(TransferredBytes, MaxBytes)>(1000);

--- a/website/docs/datastores.mdx
+++ b/website/docs/datastores.mdx
@@ -110,7 +110,39 @@ datastore:
 
 ## Local disk
 
-> Work in progress
+### Create a directory
+
+Replibyte does not create the directory automatically for you. You'll need to create it manually.
+
+For example, you can create a directory by running:
+
+```sh
+mkdir /data/replibyte
+```
+
+### Replibyte configuration
+
+Here is the datastore configuration to use:
+
+```yaml
+...
+datastore:
+  local_disk:
+    dir: <your_directory_path>
+...
+```
+
+`dir` must be a readable and writable directory to the user running `replibyte`.
+
+So, to use our previously created `/data/replibyte` directory, the datastore config must be:
+
+```yaml
+...
+datastore:
+  local_disk:
+    dir: /data/replibyte
+...
+```
 
 ## Add another datastore
 


### PR DESCRIPTION
This PR adds a new local_disk datastore which stores the dump on the local filesystem.

The datastore configuration follows this format:

```sh
datastore:
  local_disk:
    dir: ./my-datastore # this directory should exists and needs to be writable and readable
```

It's a work in progress, it miss the following things for now.

- [x] implement delete feature
- [x] update documentation

Closes #83 