### PR TITLE
docs: Transformers - Update broken link

### DIFF
--- a/website/docs/transformers.md
+++ b/website/docs/transformers.md
@@ -4,7 +4,7 @@ sidebar_position: 7
 
 # Transformers
 
-A transformer is useful to change/hide the value of a specified column. Replibyte provides pre-made transformers. You can also [build your own Transformer in web assembly](#wasm).
+A transformer is useful to change/hide the value of a specified column. Replibyte provides pre-made transformers. You can also [build your own Transformer in web assembly](/docs/transformers#custom-with-web-assembly-wasm).
 
 :::note
 


### PR DESCRIPTION
## Description

Hello,

This link is broken 

![image](https://user-images.githubusercontent.com/23166349/168432576-db6bafcc-f387-4774-ab4c-181b85d0cafd.png)

I guess the idea is to redirect the reader to the section at the bottom of the page. But, maybe consider redirecting the user to the guide in question (`/docs/advanced-guides/web-assembly-transformer`) would be better. 