### PR TITLE
Fix #120, decode username to allow users special chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "lazy_static",
  "log",
  "machine-uid",
+ "percent-encoding",
  "prettytable-rs",
  "rand 0.8.5",
  "reqwest",

--- a/replibyte/Cargo.toml
+++ b/replibyte/Cargo.toml
@@ -40,6 +40,7 @@ ctrlc = "3.2.1"
 reqwest = { version = "0.11", features = ["blocking"] }
 chrono = {version = "0.4", features = ["serde"] }
 machine-uid = "0.2"
+percent-encoding = "2.1.0"
 
 # FIXME removed until the CI release pipeline is fixed
 #wasmer = { version = "2.2", optional = true }


### PR DESCRIPTION
Hi @evoxmusic, small `pr` to fix #120 and allow usernames with special chars (e.g `@`). 
Thanks and happy birthday!!