### PR TITLE
feat: publish official replibyte container image to Github Packages

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,36 @@
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
+          # shortcut to create `latest` tag
+          flavor: latest=true
+
+      - uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN cargo build --release
 # our final base
 FROM rust:1.59-slim-buster
 
+# used to configure Github Packages
+LABEL org.opencontainers.image.source https://github.com/qovery/replibyte
+
 # Install Postgres and MySQL binaries
 RUN apt-get clean && apt-get update && apt-get install -y \
     wget \

--- a/website/docs/guides/deploy-replibyte/container.md
+++ b/website/docs/guides/deploy-replibyte/container.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Deploy Replibyte as a container
 
-You are using Replibyte on your local machine to [create](/docs/guides/create-a-dump) and [restore dumps](/docs/guides/restore-a-dump), it's great, but now you might want to deploy it close to your production and development environments to automate the process. This step-by-step guide explains how to do it and share you best practices. 
+You are using Replibyte on your local machine to [create](/docs/guides/create-a-dump) and [restore dumps](/docs/guides/restore-a-dump), it's great, but now you might want to deploy it close to your production and development environments to automate the process. This step-by-step guide explains how to do it and share you best practices.
 
 :::note for qovery users
 
@@ -18,30 +18,24 @@ Here is a schema of what we are going to put in place.
 ![schema Replibyte](/img/replibyte_dump_and_restore.jpg)
 
 1. In production:
-   1. Replibyte periodically dump the production database and.. 
+   1. Replibyte periodically dump the production database and..
    2. upload a dump **without the sensitive data** on a S3 bucket.
 2. In development:
-   1. Replibyte periodically restore the development database with the latest dump. 
+   1. Replibyte periodically restore the development database with the latest dump.
 
 Let's go!
 
-## Create a container with Replibyte
+## Run Replibyte container locally
 
-:::note
+### Download the official Replibyte image
 
-I assume Docker is already installed and running.
+```sh
+docker pull ghcr.io/qovery/replibyte
+```
+
+Check the [Github package](https://github.com/qovery/replibyte/pkgs/container/replibyte) for available tags (currently `latest` and per git release tag).
 
 :::
-
-To deploy Replibyte, I will put the Replibyte binary into a linux Docker container image. It is an easy way to make Replibyte working everywhere.
-
-Here are the steps:
-
-### Create an empty directory `replibyte-container`
-
-```shell
-mkdir replibyte-container && cd replibyt-container
-```
 
 ### Create Replibyte configuration file
 
@@ -79,127 +73,31 @@ destination:
   connection_uri: $DESTINATION_CONNECTION_URI
 ```
 
-Save it into your `replibyte-container` directory.
+And set your environment variables in a file. You can leave secure environment variables empty so that they read from the shell environment.
 
-### Create container
-
-Copy/paste the following Dockerfile in your `replibyte-container` directory
-
-```dockerfile title="Dockerfile"
-FROM debian:buster as replibyte
-
-RUN apt clean && apt update && apt install -y jq wget curl
-
-WORKDIR replibyte
-
-# Download latest Replibyte binary
-RUN curl -s https://api.github.com/repos/Qovery/replibyte/releases/latest | jq -r '.assets[].browser_download_url' | grep -i 'tar.gz$' | wget -qi - && \
-    tar zxf *.tar.gz && \
-    mv `ls replibyte*-linux-musl` replibyte && \
-    chmod +x replibyte
-
-ENV PATH="/replibyte:${PATH}"
-
-ARG S3_ACCESS_KEY_ID
-ENV S3_ACCESS_KEY_ID $S3_ACCESS_KEY_ID
-
-ARG S3_SECRET_ACCESS_KEY
-ENV S3_SECRET_ACCESS_KEY $S3_SECRET_ACCESS_KEY
-
-ARG S3_REGION
-ENV S3_REGION $S3_REGION
-
-ARG S3_BUCKET
-ENV S3_BUCKET $S3_BUCKET
-
-ARG SOURCE_CONNECTION_URI
-ENV SOURCE_CONNECTION_URI $SOURCE_CONNECTION_URI
-
-ARG DESTINATION_CONNECTION_URI
-ENV DESTINATION_CONNECTION_URI $DESTINATION_CONNECTION_URI
-
-ARG ENCRYPTION_SECRET
-ENV ENCRYPTION_SECRET $ENCRYPTION_SECRET
-
-COPY replibyte.yaml .
+```sh
+$ cat env.txt
+S3_ACCESS_KEY_ID
+S3_SECRET_ACCESS_KEY
+S3_REGION=us-east-2
+S3_BUCKET=my-test-bucket
+SOURCE_CONNECTION_URI=postgres://...
+DESTINATION_CONNECTION_URI=postgres://...
+ENCRYPTION_SECRET
 ```
 
-:::caution
+### Start the container
 
-Never hard code credentials in a Dockerfile
-
-:::
-
-If you run `ls -lh` you must see 2 files.
-
-```shell
-ls -lh
-
-.rw-r--r--   890 xxx  6 May 14:00  Dockerfile
-.rw-r--r--   588 xxx  6 May 14:00  replibyte.yaml
+```sh
+docker run -it --name replibyte \
+    --env-file env.txt \
+    -v "$(pwd)/replibyte.yaml":/replibyte.yaml:ro \
+    ghcr.io/qovery/replibyte \
 ```
 
-And now you can check that you successfully build your container with `docker build -f Dockerfile -t replibyte:latest .`
+## Running in a cloud environment
 
-```shell
-docker build -f Dockerfile -t replibyte:latest .
-
-
-[+] Building 1.2s (10/10) FINISHED
- => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                         0.0s
- => => transferring dockerfile: 47B                                                                                                                                                                                                                                                                                                                                                    0.0s
- => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                      0.0s
- => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                                        0.0s
- => [internal] load metadata for docker.io/library/debian:buster                                                                                                                                                                                                                                                                                                                       1.1s
- => [1/5] FROM docker.io/library/debian:buster@sha256:ebe4b9831fb22dfa778de4ffcb8ea0ad69b5d782d4e86cab14cc1fded5d8e761                                                                                                                                                                                                                                                                 0.0s
- => [internal] load build context                                                                                                                                                                                                                                                                                                                                                      0.0s
- => => transferring context: 36B                                                                                                                                                                                                                                                                                                                                                       0.0s
- => CACHED [2/5] RUN apt clean && apt update && apt install -y jq wget curl                                                                                                                                                                                                                                                                                                            0.0s
- => CACHED [3/5] WORKDIR replibyte                                                                                                                                                                                                                                                                                                                                                     0.0s
- => CACHED [4/5] RUN curl -s https://api.github.com/repos/Qovery/replibyte/releases/latest | jq -r '.assets[].browser_download_url' | grep -i 'tar.gz$' | wget -qi - &&     tar zxf *.tar.gz &&     mv `ls replibyte*-linux-musl` replibyte &&     chmod +x replibyte                                                                                                                  0.0s
- => CACHED [5/5] COPY replibyte.yaml .                                                                                                                                                                                                                                                                                                                                                 0.0s
- => exporting to image                                                                                                                                                                                                                                                                                                                                                                 0.0s
- => => exporting layers                                                                                                                                                                                                                                                                                                                                                                0.0s
- => => writing image sha256:1781d25593a71df493d686eb9db889a705949e6881be38b0d28cc436da8810f6
-```
-
-And you can try your container with `docker run replibyte:latest replibyte`
-
-```shell
-docker run replibyte:latest replibyte
-
-
-Replibyte is a tool to seed your databases with your production data while keeping sensitive data safe, just pass `-h`
-
-USAGE:
-    replibyte [OPTIONS] --config <configuration file> <SUBCOMMAND>
-
-OPTIONS:
-    -c, --config <configuration file>    replibyte configuration file
-    -h, --help                           Print help information
-    -n, --no-telemetry                   disable telemetry
-    -V, --version                        Print version information
-
-SUBCOMMANDS:
-    dump           all backup commands
-    help           Print this message or the help of the given subcommand(s)
-    transformer    all transformers command
-```
-
-If you want to run your Replibyte command properly, you will need to pass all the arguments with the `docker run -e` parameter. E.g:
-
-```shell
-docker run -e S3_ACCESS_KEY_ID=XXX \
-           -e S3_SECRET_ACCESS_KEY=YYY \
-           -e S3_REGION=us-east-2 \
-           -e S3_BUCKET=my-test-bucket \
-           -e SOURCE_CONNECTION_URI=postgres://... \
-           -e DESTINATION_CONNECTION_URI=postgres://... \
-           -e ENCRYPTION_SECRET=itIsASecret \
-           replibyte:latest replibyte dump create
-```
-
-## Deploy container
+### Deploy with Qovery
 
 ---
 
@@ -213,32 +111,9 @@ To deploy Replibyte with Qovery - [here are the instructions](/docs/guides/deplo
 
 ---
 
-Once you have built and tried your container, you need to push it into a Container Registry. The most popular one is [Docker Hub](https://hub.docker.com). But you can use any other Container Registry like [AWS ECR](https://aws.amazon.com/ecr/), [Google GCR](https://cloud.google.com/container-registry), [Quay](https://quay.io/)... Here, I will use Docker Hub which is free and easy to use.
+### Self-hosted Deployment
 
-To push your container image in Docker Hub you need to run the following commands:
-
-:::tip
-
-You need to sign up on [Docker Hub](https://hub.docker.com).
-
-:::
-
-```shell title="Auth yourself"
-docker login --username=yourhubusername --email=youremail@company.com
-
-WARNING: login credentials saved in /home/username/.docker/config.json
-Login Succeeded
-```
-
-```shell
-docker push your_docker_hub_username/replibyte:latest
-```
-
-That's it! You are ready to pull and run your replibyte image from anywhere.
-
-## Deployment
-
-This part depends on the platform (E.g Kubernetes, Docker Swarm, Nomad...) you use to deploy your containers. Basically, you just need to pull the container you pushed, and run it with the good parameters.
+This part depends on the platform (E.g Kubernetes, Docker Swarm, Nomad...) you use to deploy your containers. Basically, you just need to pull the container and run it with the right parameters.
 
 ### Parameters for production
 
@@ -252,7 +127,7 @@ docker run -e S3_ACCESS_KEY_ID=XXX \
            -e SOURCE_CONNECTION_URI=postgres://... \
            -e DESTINATION_CONNECTION_URI=postgres://... \
            -e ENCRYPTION_SECRET=itIsASecret \
-           replibyte:latest replibyte dump create
+           ghcr.io/qovery/replibyte replibyte dump create
 ```
 
 ### Parameters to seed development databases
@@ -267,7 +142,7 @@ docker run -e S3_ACCESS_KEY_ID=XXX \
            -e SOURCE_CONNECTION_URI=postgres://... \
            -e DESTINATION_CONNECTION_URI=postgres://... \
            -e ENCRYPTION_SECRET=itIsASecret \
-           replibyte:latest replibyte dump restore remote -v latest
+           ghcr.io/qovery/replibyte replibyte dump restore remote -v latest
 ```
 
 ---


### PR DESCRIPTION
Closes #97 

## Features

- create a Github Actions workflow `publish-image` to build, tag, and push a Docker image based on the [root-level Dockerfile](https://github.com/Qovery/Replibyte/blob/main/Dockerfile)
    - workflow only runs when a Github release is published (same as how the [binaries are currently released](https://github.com/Qovery/Replibyte/blob/b673d7a2aa5a3dfbb89cfec9cf4911b5199311b7/.github/workflows/on-release.yml#L1-L4))
    - image is pushed to Github Container Registry (`ghcr.io`) with the following tags
        - `latest`
        - if the release tag is `v<version>`, there will also be a tag `replibyte:<version>` (without the `v`)
- Updated the documentation on running Replibyte as a container to use the published image, instead of building a custom image

## Testing
I tested an [almost identical config](https://github.com/wtait1-ff/image-push-test/blob/main/.github/workflows/publish-image.yaml) by pushing it to a completely new repo, without any settings changed. The first Github release automatically created a [Github package](https://github.com/wtait1-ff/image-push-test/pkgs/container/test-publish) that was publicly viewable, so nothing should need to be done outside of merging + releasing this PR (ex. don't need to manually create the package first)