### PR TITLE
chore: improve release script by checking if the pull request is merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ yarn-debug.log*
 yarn-error.log*
 
 /my-datastore
+
+*.release

--- a/release.sh
+++ b/release.sh
@@ -24,7 +24,7 @@ then
     read -r answer
 fi
 
-echo -n "Release process from starting from '${old}' -> '${new}', do you want to continue? [y/N] "
+echo -n "Release process starting from '${old}' -> '${new}', do you want to continue? [y/N] "
 read -r answer
 
 
@@ -72,13 +72,28 @@ echo
 echo "  >> https://github.com/qovery/replibyte/pull/new/release-v${new} <<"
 echo
 echo "Once you continue we'll generate and push the release tag with the latest 'main'"
+echo
+echo "WARNING: Review and wait until the pull request is merged before continuing to create the release"
 read -r answer
 
 echo "Generating release tag v${new}"
 
 git checkout main
 git pull
-git tag -a -m"Release v${new}" "v${new}"
-git push --tags
 
-echo "Congrats release v${new} is done!"
+# The version is correctly updated in the replibyte crate cargo.toml (aka the PR is merged)
+if grep -q  "version = \"${new}\"" ${TOML_FILES[0]}; then
+    git tag -a -m"Release v${new}" "v${new}"
+    git push --tags
+
+    echo "Congrats release v${new} is done!"
+else
+    echo
+    echo "It seems the version is not updated, are you sure you have merged the pull request as stated before?"
+    echo "If that's not the case, you're invited to run again the release script and wait for the PR is merged before continuing."
+    echo
+    echo "Rollback changes"
+
+    git branch -d "release-v${new}"
+    git push origin --delete "release-v${new}"
+fi


### PR DESCRIPTION
@evoxmusic I've added a check before creating and pushing the tag.

If the version in the replibyte Cargo.toml file doesn't contain the right version, I delete the release branch from local and remote repository to rollback.