### PR TITLE
Fix: parsing statements with comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dump-parser"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bson",
  "crc",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "replibyte"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2693,7 +2693,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subset"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "dump-parser",
  "md5",

--- a/dump-parser/src/postgres/mod.rs
+++ b/dump-parser/src/postgres/mod.rs
@@ -3,8 +3,8 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 use crate::postgres::Keyword::{
-    Add, Alter, Constraint, Copy, Create, Database, Foreign, From, Insert, Into as KeywordInto,
-    Key, NoKeyword, Not, Null, Only, Primary, References, Table,
+    Add, Alter, Constraint, Copy, Create, Database, Foreign, From, Function, Insert,
+    Into as KeywordInto, Key, NoKeyword, Not, Null, Only, Primary, References, Replace, Table,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -127,6 +127,7 @@ impl Token {
                 match word_uppercase.as_str() {
                     "ALTER" => Alter,
                     "CREATE" => Create,
+                    "REPLACE" => Replace,
                     "INSERT" => Insert,
                     "ONLY" => Only,
                     "INTO" => KeywordInto,
@@ -142,6 +143,7 @@ impl Token {
                     "FOREIGN" => Foreign,
                     "REFERENCES" => References,
                     "KEY" => Key,
+                    "FUNCTION" => Function,
                     _ => NoKeyword,
                 }
             } else {
@@ -170,6 +172,7 @@ pub struct Word {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Keyword {
     Create,
+    Replace,
     Alter,
     Only,
     Insert,
@@ -186,6 +189,7 @@ pub enum Keyword {
     Foreign,
     References,
     Key,
+    Function,
     NoKeyword,
 }
 


### PR DESCRIPTION
This PR fix statements with multiple comments like this one below:

```sql
-- this is a first comment
-- this is a second comment
SELECT * -- this is a third comment
FROM user -- this is a fourth comment
-- this is a fifth comment
WHERE age > 18;
```