### PR TITLE
feat(destination): add ability to disable schema wipe

### DIFF
--- a/examples/replibyte.yaml
+++ b/examples/replibyte.yaml
@@ -11,6 +11,8 @@ source:
           transformer_name: random # TO CHANGE
 destination:
   connection_uri: $DESTINATION_CONNECTION_URI
+  # Wipe the public schema
+  # wipe_database: false (default: true)
 datastore:
   aws:
     bucket: $S3_BUCKET

--- a/replibyte/src/commands/dump.rs
+++ b/replibyte/src/commands/dump.rs
@@ -441,7 +441,7 @@ where
                         database.as_str(),
                         username.as_str(),
                         password.as_str(),
-                        true,
+                        destination.wipe_database.unwrap_or(true),
                     );
 
                     let task = FullRestoreTask::new(&mut postgres, datastore, options);

--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -223,6 +223,7 @@ impl SourceConfig {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct DestinationConfig {
     pub connection_uri: String,
+    pub wipe_database: Option<bool>
 }
 
 impl DestinationConfig {

--- a/website/docs/guides/2-restore-a-dump.md
+++ b/website/docs/guides/2-restore-a-dump.md
@@ -80,6 +80,8 @@ To restore on a remote database, you need to specify the destination connection 
 ```yaml title="conf.yaml"
 destination:
   connection_uri: postgres://user:password@host:port/db
+  # Disable public's schema wipe
+  # wipe_database: false (default: true)
 ```
 
 and run the following command:


### PR DESCRIPTION
## Feature
This pr had the ability, for a user, to disable the public schema wipe, that was done by default.
In our case, we didn't want to touch the public schema

This is a non-breaking change