### PR TITLE
feat: atlas support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dump-parser"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bson",
  "crc",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "replibyte"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2693,7 +2693,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subset"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "dump-parser",
  "md5",

--- a/replibyte/src/commands/dump.rs
+++ b/replibyte/src/commands/dump.rs
@@ -139,19 +139,13 @@ where
                         task.run(progress_callback)?
                     }
                     ConnectionUri::MongoDB(
-                        host,
-                        port,
-                        username,
-                        password,
+                        uri,
                         database,
                         authentication_db,
                     ) => {
                         let mongodb = MongoDB::new(
-                            host.as_str(),
-                            port,
+                            uri.as_str(),
                             database.as_str(),
-                            username.as_str(),
-                            password.as_str(),
                             authentication_db.as_str(),
                         );
 
@@ -459,19 +453,13 @@ where
                     task.run(progress_callback)?;
                 }
                 ConnectionUri::MongoDB(
-                    host,
-                    port,
-                    username,
-                    password,
+                    uri,
                     database,
                     authentication_db,
                 ) => {
                     let mut mongodb = destination::mongodb::MongoDB::new(
-                        host.as_str(),
-                        port,
+                        uri.as_str(),
                         database.as_str(),
-                        username.as_str(),
-                        password.as_str(),
                         authentication_db.as_str(),
                     );
 

--- a/replibyte/src/datastore/local_disk.rs
+++ b/replibyte/src/datastore/local_disk.rs
@@ -252,7 +252,8 @@ impl Datastore for LocalDisk {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, path::Path};
+    use std::{fs::OpenOptions};
+    use std::path::Path;
 
     use chrono::{Duration, Utc};
     use serde_json::json;

--- a/replibyte/src/telemetry.rs
+++ b/replibyte/src/telemetry.rs
@@ -86,7 +86,7 @@ impl TelemetryClient {
                     match x.connection_uri()? {
                         ConnectionUri::Postgres(_, _, _, _, _) => "postgresql",
                         ConnectionUri::Mysql(_, _, _, _, _) => "mysql",
-                        ConnectionUri::MongoDB(_, _, _, _, _, _) => "mongodb",
+                        ConnectionUri::MongoDB(_, _, _) => "mongodb",
                     }
                     .to_string(),
                 );

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -16,7 +16,7 @@ For local development, you will need to:
 
 1. Install [Rust](https://www.rust-lang.org/).
 2. Install [Docker](https://www.docker.com).
-3. Run `docker compose -f ./docker-compose-dev.yml` to
+3. Run `docker compose -f ./docker-compose-dev.yml up` to
 start the local databases. At the moment, `docker-compose` includes 2 PostgreSQL database instances, 2 MySQL instances, 2 MongoDB instances
 and a [MinIO](https://min.io) datastore. One source, one destination by database and one datastore. In the future, we will provide more options.
 

--- a/website/docs/guides/1-create-a-dump.md
+++ b/website/docs/guides/1-create-a-dump.md
@@ -53,7 +53,7 @@ source:
 
 ```yaml
 source:
-  connection_uri: mongo://[user]:[password]@[host]:[port]/[database]
+  connection_uri: mongodb://[user]:[password]@[host]:[port]/[database]
 ```
 
 </details>


### PR DESCRIPTION
This PR has a few changes, but includes primarily the functionality to pass the mongo URI directly to mongosh and mongodump/mongorestore.

This also includes moving from `mongo` to `mongosh`, as the former is deprecated.

Should resolve issue #135