### PR TITLE
fix: tokenize username in database wipe

### DIFF
--- a/replibyte/src/destination/postgres.rs
+++ b/replibyte/src/destination/postgres.rs
@@ -104,7 +104,7 @@ fn wipe_database_query(username: &str) -> String {
         "\
     DROP SCHEMA public CASCADE; \
     CREATE SCHEMA public; \
-    GRANT ALL ON SCHEMA public TO {}; \
+    GRANT ALL ON SCHEMA public TO \"{}\"; \
     GRANT ALL ON SCHEMA public TO public;\
     ",
         username


### PR DESCRIPTION
This PR fixes an issue when wiping the public schema for a username that needed tokenization