### PR TITLE
fix(mongo): remove the '--authenticationDatabase' option from mongo commands as we pass the '--uri' option

### DIFF
--- a/replibyte/src/commands/dump.rs
+++ b/replibyte/src/commands/dump.rs
@@ -138,16 +138,8 @@ where
                         let task = FullDumpTask::new(mysql, datastore, options);
                         task.run(progress_callback)?
                     }
-                    ConnectionUri::MongoDB(
-                        uri,
-                        database,
-                        authentication_db,
-                    ) => {
-                        let mongodb = MongoDB::new(
-                            uri.as_str(),
-                            database.as_str(),
-                            authentication_db.as_str(),
-                        );
+                    ConnectionUri::MongoDB(uri, database) => {
+                        let mongodb = MongoDB::new(uri.as_str(), database.as_str());
 
                         let task = FullDumpTask::new(mongodb, datastore, options);
                         task.run(progress_callback)?
@@ -452,16 +444,9 @@ where
                     let task = FullRestoreTask::new(&mut mysql, datastore, options);
                     task.run(progress_callback)?;
                 }
-                ConnectionUri::MongoDB(
-                    uri,
-                    database,
-                    authentication_db,
-                ) => {
-                    let mut mongodb = destination::mongodb::MongoDB::new(
-                        uri.as_str(),
-                        database.as_str(),
-                        authentication_db.as_str(),
-                    );
+                ConnectionUri::MongoDB(uri, database) => {
+                    let mut mongodb =
+                        destination::mongodb::MongoDB::new(uri.as_str(), database.as_str());
 
                     let task = FullRestoreTask::new(&mut mongodb, datastore, options);
                     task.run(progress_callback)?

--- a/replibyte/src/source/mongodb.rs
+++ b/replibyte/src/source/mongodb.rs
@@ -283,11 +283,17 @@ mod tests {
     use super::recursively_transform_document;
 
     fn get_mongodb() -> MongoDB<'static> {
-        MongoDB::new("mongodb://root:password@localhost:27018/", "test")
+        MongoDB::new(
+            "mongodb://root:password@localhost:27018/test?authSource=admin",
+            "test",
+        )
     }
 
     fn get_invalid_mongodb() -> MongoDB<'static> {
-        MongoDB::new("mongodb://root:wrongpassword@localhost:27018/", "test")
+        MongoDB::new(
+            "mongodb://root:wrongpassword@localhost:27018/test?authSource=admin",
+            "test",
+        )
     }
 
     #[test]

--- a/replibyte/src/source/mongodb.rs
+++ b/replibyte/src/source/mongodb.rs
@@ -15,20 +15,11 @@ use dump_parser::mongodb::Archive;
 pub struct MongoDB<'a> {
     uri: &'a str,
     database: &'a str,
-    authentication_db: &'a str,
 }
 
 impl<'a> MongoDB<'a> {
-    pub fn new(
-        uri: &'a str,
-        database: &'a str,
-        authentication_db: &'a str,
-    ) -> Self {
-        MongoDB {
-            uri,
-            database,
-            authentication_db
-        }
+    pub fn new(uri: &'a str, database: &'a str) -> Self {
+        MongoDB { uri, database }
     }
 }
 
@@ -58,8 +49,6 @@ impl<'a> Source for MongoDB<'a> {
                 self.uri,
                 "--db",
                 self.database,
-                "--authenticationDatabase",
-                self.authentication_db,
                 "--archive", // dump to stdin
             ])
             .stdout(Stdio::piped())
@@ -86,12 +75,7 @@ fn check_connection_status(db: &MongoDB) -> Result<(), Error> {
         .spawn()?;
 
     let mut mongo_process = Command::new("mongosh")
-        .args([
-            db.uri,
-            "--authenticationDatabase",
-            db.authentication_db,
-            "--quiet"
-        ])
+        .args([db.uri, "--quiet"])
         .stdin(echo_process.stdout.take().unwrap())
         .stdout(Stdio::inherit())
         .spawn()?;
@@ -299,11 +283,11 @@ mod tests {
     use super::recursively_transform_document;
 
     fn get_mongodb() -> MongoDB<'static> {
-        MongoDB::new("mongodb://root:password@localhost:27018/", "test", "admin")
+        MongoDB::new("mongodb://root:password@localhost:27018/", "test")
     }
 
     fn get_invalid_mongodb() -> MongoDB<'static> {
-        MongoDB::new("mongodb://root:wrongpassword@localhost:27018/", "test", "admin")
+        MongoDB::new("mongodb://root:wrongpassword@localhost:27018/", "test")
     }
 
     #[test]

--- a/replibyte/src/telemetry.rs
+++ b/replibyte/src/telemetry.rs
@@ -86,7 +86,7 @@ impl TelemetryClient {
                     match x.connection_uri()? {
                         ConnectionUri::Postgres(_, _, _, _, _) => "postgresql",
                         ConnectionUri::Mysql(_, _, _, _, _) => "mysql",
-                        ConnectionUri::MongoDB(_, _, _) => "mongodb",
+                        ConnectionUri::MongoDB(_, _) => "mongodb",
                     }
                     .to_string(),
                 );


### PR DESCRIPTION
Hi @evoxmusic 
This PR https://github.com/Qovery/Replibyte/pull/154 makes a change in the different mongo commands to use the `--uri` option and pass the connection string directly so we no longer need to pass the `--authenticationDatabase` option as the authSource is directly included in the uri.

As stated in this issue/comment  https://github.com/Qovery/Replibyte/issues/147#issuecomment-1149945859 it even introduces an error (depending on the mongodump/mongorestore you're using I guess)
 