### PR TITLE
fix: ignore triggers on dump to prevent TokenizerError

### DIFF
--- a/replibyte/src/source/mysql.rs
+++ b/replibyte/src/source/mysql.rs
@@ -81,6 +81,7 @@ impl<'a> Source for Mysql<'a> {
             "--complete-insert",   // have column names in INSERT INTO rows
             "--single-transaction", // https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction
             "--quick", // reads out large tables in a way that doesn't require having enough RAM to fit the full table in memory
+            "--skip-triggers",
             self.database,
         ];
 


### PR DESCRIPTION
Hello,

This PR will resolves the panic mentioned in #170. I was able to reproduce the error by adding an empty trigger on any table in the source database.

Closes #170 