### PR TITLE
Fix typo in the URL

### DIFF
--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,3 +1,3 @@
 # RepliByte with a custom WebAssembly transformer
 
-Check out the [official guide here](https://www.replibyte.com/docs/advanced-guides/web-assembly-transfotmer)
+Check out the [official guide here](https://www.replibyte.com/docs/advanced-guides/web-assembly-transformer)


### PR DESCRIPTION
The previous URL had a typo, and resulted in a 404 page.