### PR TITLE
Add `--hex-blob` to mysqldump

### DIFF
--- a/replibyte/src/source/mysql.rs
+++ b/replibyte/src/source/mysql.rs
@@ -81,6 +81,7 @@ impl<'a> Source for Mysql<'a> {
             "--complete-insert",   // have column names in INSERT INTO rows
             "--single-transaction", // https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction
             "--quick", // reads out large tables in a way that doesn't require having enough RAM to fit the full table in memory
+            "--hex-blob",
             "--databases",
             self.database,
         ];


### PR DESCRIPTION
We use UUIDs as BINARY(16) primary keys, without `--hex-blob` I get a UTF8Error when dumping.
Not sure if there are any downsides to adding this though.