### PR TITLE
Wrap table name to qoutes when creating transformers map for PostgreSQL (#174)

### DIFF
--- a/replibyte/src/source/postgres.rs
+++ b/replibyte/src/source/postgres.rs
@@ -199,7 +199,7 @@ pub fn read_and_transform<R: Read, F: FnMut(OriginalQuery, Query)>(
 
     for transformer in options.transformers {
         let _ = transformer_by_db_and_table_and_column_name.insert(
-            transformer.database_and_table_and_column_name(),
+            transformer.database_and_quoted_table_and_column_name(),
             transformer,
         );
     }

--- a/replibyte/src/transformer/mod.rs
+++ b/replibyte/src/transformer/mod.rs
@@ -43,6 +43,16 @@ pub trait Transformer {
     fn database_name(&self) -> &str;
     fn table_name(&self) -> &str;
     fn column_name(&self) -> &str;
+    fn quoted_table_name(&self) -> String {
+        let table_name = self.table_name();
+
+        if table_name.to_lowercase() != table_name {
+            return format!("\"{}\"", table_name);
+        }
+
+        String::from(table_name)
+    }
+
     fn database_and_table_name(&self) -> String {
         format!("{}.{}", self.database_name(), self.table_name())
     }
@@ -52,6 +62,15 @@ pub trait Transformer {
             "{}.{}.{}",
             self.database_name(),
             self.table_name(),
+            self.column_name()
+        )
+    }
+
+    fn database_and_quoted_table_and_column_name(&self) -> String {
+        format!(
+            "{}.{}.{}",
+            self.database_name(),
+            self.quoted_table_name(),
             self.column_name()
         )
     }


### PR DESCRIPTION
Closes #174.