### PR TITLE
Fixes a number of sql parser bugs

### DIFF
--- a/dump-parser/src/postgres/mod.rs
+++ b/dump-parser/src/postgres/mod.rs
@@ -530,20 +530,22 @@ impl<'a> Tokenizer<'a> {
         let mut s = String::new();
         chars.next(); // consume the opening quote
 
-        // slash escaping is specific to some dialect
-        let mut is_escaped = false;
+        // PostgreSQL - https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-BACKSLASH-TABLE
+        // in postgres quotes are escaped with ''
         while let Some(&ch) = chars.peek() {
             match ch {
                 '\'' => {
-                    chars.next(); // consume
-                    if is_escaped {
-                        s.push(ch);
-                        is_escaped = false;
-                    } else if chars.peek().map(|c| *c == '\'').unwrap_or(false) {
-                        s.push(ch);
-                        chars.next();
-                    } else {
-                        return Ok(s);
+                    chars.next(); // consume '
+                    match chars.peek() {
+                        // escaped
+                        Some('\'') => {
+                            chars.next(); // consume second '
+                            s.push('\'');
+                            s.push('\'');
+                        }
+                        _ => {
+                            return Ok(s);
+                        }
                     }
                 }
                 _ => {

--- a/dump-parser/src/utils.rs
+++ b/dump-parser/src/utils.rs
@@ -248,7 +248,10 @@ fn list_statements(query: &str) -> Vec<Statement> {
                 previous_chars_are_whitespaces = false;
             }
             // use grapheme instead of code points or bytes?
-            b'-' if !is_statement_complete && is_next_char_comment(next_idx) => {
+            b'-' if !is_statement_complete 
+                && is_next_char_comment(next_idx)
+                && stack.get(0) != Some(&b'\'') =>
+            {
                 // comment
                 is_partial_comment_line = true;
                 previous_chars_are_whitespaces = false;
@@ -388,6 +391,23 @@ Etiam augue augue, bibendum et molestie non, finibus non nulla. Etiam quis rhonc
 
         let s = list_statements(
             "INSERT INTO public.toto (first_name, last_name) VALUES ('jo)hn', 'd(oe');",
+        );
+        assert_eq!(s.len(), 1);
+
+        match s.get(0).unwrap() {
+            Statement::NewLine => {
+                assert!(false);
+            }
+            Statement::CommentLine(_) => {
+                assert!(false);
+            }
+            Statement::Query(s) => {
+                assert!(s.valid);
+            }
+        }
+
+        let s = list_statements(
+            "INSERT INTO public.toto (first_name, last_name) VALUES ('jo--hn', 'd;--oe');",
         );
         assert_eq!(s.len(), 1);
 


### PR DESCRIPTION
A number of fixes to unblock our use cases.
These should potentially fix a number of open issues.

1. Single quoted tests containing a quote were broken, as a result parsing was broken on our MySQL dumps.
2. Single quoted string tokenization containing -- was broken.
3. 30MB MySQL dump would do not finish in 30minutes due to slow fallback for utf8 strings with multibyte characters.

Best to review each commit separately.
d68a435 - Potentially fixes #124, #169, as well as incorrect escaped quote parsing, which would cascade to other issues.
29bba0a - Potentially fixes #200, #189, #184, #92 as from the brief look the slow path is O(c<sup>n</sup>). 

I have not run integration tests, as I don't have docker on the current machine.