### PR TITLE
Fix/numeric parsing

### DIFF
--- a/dump-parser/src/postgres/mod.rs
+++ b/dump-parser/src/postgres/mod.rs
@@ -11,7 +11,7 @@ use crate::postgres::Keyword::{
 pub enum Token {
     /// An end-of-file marker, not a real token
     EOF,
-    /// An unsigned numeric literal
+    /// An unsigned numeric literal (numeric string, is_long)
     Number(String, bool),
     /// TABLE instruction
     Word(Word),
@@ -743,9 +743,13 @@ pub fn get_column_values_str_from_insert_into_query(tokens: &Vec<Token>) -> Vec<
         .filter_map(|x| match *x {
             Token::Word(word) => Some(word.value.clone()),
             Token::SingleQuotedString(word) => Some(word.clone()),
-            Token::Number(value, is_negative) => Some(match is_negative {
+            Token::Number(value, is_long) => Some(match is_long {
                 false => value.clone(),
-                true => format!("-{}", value),
+                true => {
+                    let mut long_value = value.to_owned();
+                    long_value.push('L');
+                    long_value
+                },
             }),
             _ => None,
         })

--- a/dump-parser/src/postgres/mod.rs
+++ b/dump-parser/src/postgres/mod.rs
@@ -330,39 +330,7 @@ impl<'a> Tokenizer<'a> {
                     Ok(Some(Token::SingleQuotedString(s)))
                 }
                 // numbers and period
-                '0'..='9' | '.' => {
-                    let mut s = peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
-
-                    // match binary literal that starts with 0x
-                    if s == "0" && chars.peek() == Some(&'x') {
-                        chars.next();
-                        let s2 = peeking_take_while(
-                            chars,
-                            |ch| matches!(ch, '0'..='9' | 'A'..='F' | 'a'..='f'),
-                        );
-                        return Ok(Some(Token::HexStringLiteral(s2)));
-                    }
-
-                    // match one period
-                    if let Some('.') = chars.peek() {
-                        s.push('.');
-                        chars.next();
-                    }
-                    s += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
-
-                    // No number -> Token::Period
-                    if s == "." {
-                        return Ok(Some(Token::Period));
-                    }
-
-                    let long = if chars.peek() == Some(&'L') {
-                        chars.next();
-                        true
-                    } else {
-                        false
-                    };
-                    Ok(Some(Token::Number(s, long)))
-                }
+                '0'..='9' | '.' => self.tokenize_number_literal(chars, None),
                 // punctuation
                 '(' => self.consume_and_return(chars, Token::LParen),
                 ')' => self.consume_and_return(chars, Token::RParen),
@@ -379,6 +347,8 @@ impl<'a> Tokenizer<'a> {
                                 comment,
                             })))
                         }
+                        // This is still not exhaustive as "SELECT - 1 as test" in postgres would return a numeric -1.
+                        Some('0'..='9') => self.tokenize_number_literal(chars, Some('-')),
                         // a regular '-' operator
                         _ => Ok(Some(Token::Minus)),
                     }
@@ -394,7 +364,15 @@ impl<'a> Tokenizer<'a> {
                         _ => Ok(Some(Token::Div)),
                     }
                 }
-                '+' => self.consume_and_return(chars, Token::Plus),
+                '+' => {
+                    chars.next(); // consume the '+'
+                    match chars.peek() {
+                        // This is still not exhaustive as "SELECT + 1 as test" in postgres would return a numeric 1.
+                        Some('0'..='9') => self.tokenize_number_literal(chars, Some('+')),
+                        // a regular '-' operator
+                        _ => Ok(Some(Token::Plus)),
+                    }
+                }
                 '*' => self.consume_and_return(chars, Token::Mul),
                 '%' => self.consume_and_return(chars, Token::Mod),
                 '|' => {
@@ -556,6 +534,51 @@ impl<'a> Tokenizer<'a> {
         }
 
         self.tokenizer_error("Unterminated string literal")
+    }
+
+    // Read a signed number literal
+    fn tokenize_number_literal(
+        &self,
+        chars: &mut Peekable<Chars<'_>>,
+        sign: Option<char>
+    ) -> Result<Option<Token>, TokenizerError> {
+        let mut s = match sign {
+            Some(ch) if ch == '+' || ch == '-' => {
+                String::from(ch) + &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'))
+            }
+            Some(_) => panic!("invalid sign"),
+            None => peeking_take_while(chars, |ch| matches!(ch, '0'..='9'))
+        };
+
+        // match binary literal that starts with 0x
+        if s == "0" && chars.peek() == Some(&'x') {
+            chars.next();
+            let s2 = peeking_take_while(
+                chars,
+                |ch| matches!(ch, '0'..='9' | 'A'..='F' | 'a'..='f'),
+            );
+            return Ok(Some(Token::HexStringLiteral(s2)));
+        }
+
+        // match one period
+        if let Some('.') = chars.peek() {
+            s.push('.');
+            chars.next();
+        }
+        s += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
+
+        // No number -> Token::Period
+        if s == "." {
+            return Ok(Some(Token::Period));
+        }
+
+        let long = if chars.peek() == Some(&'L') {
+            chars.next();
+            true
+        } else {
+            false
+        };
+        Ok(Some(Token::Number(s, long)))
     }
 
     fn tokenize_multiline_comment(
@@ -981,6 +1004,27 @@ VALUES ('Romaric', true);
             vec![
                 &Token::SingleQuotedString("Romaric".to_string()),
                 &Token::make_word("true", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_insert_into_with_numbers() {
+        let q = "INSERT INTO public.test (postive_number, negative_number, long_number) VALUES (+5.75, -10.20, 20L);";
+
+        let mut tokenizer = Tokenizer::new(q);
+        let tokens_result = tokenizer.tokenize();
+        assert_eq!(tokens_result.is_ok(), true);
+
+        let tokens = trim_pre_whitespaces(tokens_result.unwrap());
+        let column_values = get_column_values_from_insert_into_query(&tokens);
+
+        assert_eq!(
+            column_values,
+            vec![
+                &Token::Number("+5.75".to_string(), false),
+                &Token::Number("-10.20".to_string(), false),
+                &Token::Number("20".to_string(), true),
             ]
         );
     }

--- a/replibyte/src/source/mysql.rs
+++ b/replibyte/src/source/mysql.rs
@@ -202,7 +202,8 @@ fn transform_columns(
     // R Paren      -> position X?
     let column_names = get_column_names_from_insert_into_query(&tokens);
     let column_values = get_column_values_from_insert_into_query(&tokens);
-
+    assert_eq!(column_names.len(), column_values.len(), "Column names do not match values: got {} names and {} values", column_names.len(), column_values.len());
+    
     let mut original_columns = vec![];
     let mut columns = vec![];
 

--- a/replibyte/src/source/postgres.rs
+++ b/replibyte/src/source/postgres.rs
@@ -296,6 +296,7 @@ fn transform_columns(
     // R Paren      -> position X?
     let column_names = get_column_names_from_insert_into_query(&tokens);
     let column_values = get_column_values_from_insert_into_query(&tokens);
+    assert_eq!(column_names.len(), column_values.len(), "Column names do not match values: got {} names and {} values", column_names.len(), column_values.len());
 
     let mut original_columns = vec![];
     let mut columns = vec![];


### PR DESCRIPTION
Fixes #204

Should be reviewed/ merged after #203 is resolved.

This introduces an assert, to make sure column name/value lists match.

https://github.com/Qovery/Replibyte/commit/c405cbac201f4cfdc2d55b88761a4a2f8f0f2ea6#diff-779da9398d8444388b74dd3391171530e14248d77cf4e4526eb66b901695079fR205
https://github.com/Qovery/Replibyte/commit/c405cbac201f4cfdc2d55b88761a4a2f8f0f2ea6#diff-c74276bcbe3d49e8387a71e14066fac0ddc12564222793e2286982ca9b596426R299

This is very much a hack, as with it incorrectly parses `2 +2`, which should be parsed as `[Number,Plus,Number]`, but would be parsed as `[Number, Number]`, but current state is much worse as any negative number `-1` would not be handled correctly.