### PR TITLE
feat: use list_buckets check bucket exists

### DIFF
--- a/replibyte/src/datastore/s3.rs
+++ b/replibyte/src/datastore/s3.rs
@@ -428,14 +428,19 @@ fn create_bucket<'a, S: AsRef<str>>(
 
     let cfg = cfg.build();
 
-    if let Ok(_) = block_on(
-        client
-            .get_bucket_accelerate_configuration()
-            .bucket(bucket)
-            .send(),
-    ) {
-        info!("bucket {} exists", bucket);
-        return Ok(());
+    if let Ok(output) = block_on(client.list_buckets().send()) {
+        if let Some(buckets) = output.buckets {
+            if buckets.iter().any(|b| {
+                if let Some(name) = &b.name {
+                    name == bucket
+                } else {
+                    false
+                }
+            }) {
+                info!("bucket {} exists", bucket);
+                return Ok(());
+            }
+        }
     }
 
     let result = block_on(


### PR DESCRIPTION
get_bucket_accelerate_configuration will return `MethodNotAllowed` (anyway, I encountered this error), so exists check always failed.

change to `list_buckets` and iterate to check if the bucket name already exists 