### PR TITLE
chore: use debain buster slim optimize image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN rm ./target/release/deps/replibyte*
 RUN cargo build --release
 
 # our final base
-FROM rust:1.59-slim-buster
+FROM debian:buster-slim
 
 # used to configure Github Packages
 LABEL org.opencontainers.image.source https://github.com/qovery/replibyte


### PR DESCRIPTION
Currently using rust:1.59-slim-buster, under my M1 mac the image size is up to 
```bash
rust 1.59-slim-buster 9e6a443fa584 4 months ago 813MB
```
 after changing to debain:cluster-slim
```bash
debian buster-slim 10fbfaf982d2 2 weeks ago 63.5MB
```
Expected to save about 10 times.