### PR TITLE
Add Buffer Size Parameter to dump create

### DIFF
--- a/replibyte/src/cli.rs
+++ b/replibyte/src/cli.rs
@@ -104,6 +104,8 @@ pub struct DumpCreateArgs {
     /// import dump from stdin
     #[clap(name = "input", short, long, requires = "source_type")]
     pub input: bool,
+    #[clap(name = "buffer_size", short, long, default_value_t = 100)]
+    pub buffer_size: usize,
     #[clap(short, long, parse(from_os_str), value_name = "dump file")]
     /// dump file
     pub file: Option<PathBuf>,

--- a/replibyte/src/commands/dump.rs
+++ b/replibyte/src/commands/dump.rs
@@ -145,7 +145,7 @@ where
                             password.as_str(),
                         );
 
-                        let task = FullDumpTask::new(postgres, datastore, options);
+                        let task = FullDumpTask::new(postgres, datastore, options, args.buffer_size);
                         task.run(progress_callback)?
                     }
                     ConnectionUri::Mysql(host, port, username, password, database) => {
@@ -157,13 +157,13 @@ where
                             password.as_str(),
                         );
 
-                        let task = FullDumpTask::new(mysql, datastore, options);
+                        let task = FullDumpTask::new(mysql, datastore, options, args.buffer_size);
                         task.run(progress_callback)?
                     }
                     ConnectionUri::MongoDB(uri, database) => {
                         let mongodb = MongoDB::new(uri.as_str(), database.as_str());
 
-                        let task = FullDumpTask::new(mongodb, datastore, options);
+                        let task = FullDumpTask::new(mongodb, datastore, options, args.buffer_size);
                         task.run(progress_callback)?
                     }
                 },
@@ -177,7 +177,7 @@ where
                     }
 
                     let postgres = PostgresStdin::default();
-                    let task = FullDumpTask::new(postgres, datastore, options);
+                    let task = FullDumpTask::new(postgres, datastore, options, args.buffer_size);
                     task.run(progress_callback)?
                 }
                 Some(v) if v == "mysql" => {
@@ -189,7 +189,7 @@ where
                     }
 
                     let mysql = MysqlStdin::default();
-                    let task = FullDumpTask::new(mysql, datastore, options);
+                    let task = FullDumpTask::new(mysql, datastore, options, args.buffer_size);
                     task.run(progress_callback)?
                 }
                 Some(v) if v == "mongodb" => {
@@ -201,7 +201,7 @@ where
                     }
 
                     let mongodb = MongoDBStdin::default();
-                    let task = FullDumpTask::new(mongodb, datastore, options);
+                    let task = FullDumpTask::new(mongodb, datastore, options, args.buffer_size);
                     task.run(progress_callback)?
                 }
                 Some(v) => {

--- a/replibyte/src/tasks/full_dump.rs
+++ b/replibyte/src/tasks/full_dump.rs
@@ -18,17 +18,19 @@ where
     source: S,
     datastore: Box<dyn Datastore>,
     options: SourceOptions<'a>,
+    arg_buffer_size: usize,
 }
 
 impl<'a, S> FullDumpTask<'a, S>
 where
     S: Source,
 {
-    pub fn new(source: S, datastore: Box<dyn Datastore>, options: SourceOptions<'a>) -> Self {
+    pub fn new(source: S, datastore: Box<dyn Datastore>, options: SourceOptions<'a>, arg_buffer_size: usize) -> Self {
         FullDumpTask {
             source,
             datastore,
             options,
+            arg_buffer_size,
         }
     }
 }
@@ -70,7 +72,7 @@ where
         });
 
         // buffer of 100MB in memory to use and re-use to upload data into datastore
-        let buffer_size = 100 * 1024 * 1024;
+        let buffer_size = self.arg_buffer_size * 1024 * 1024;
         let mut queries = vec![];
         let mut consumed_buffer_size = 0usize;
         let mut total_transferred_bytes = 0usize;


### PR DESCRIPTION
# Changelog
* Add Argument to set `buffer_size` when dumping the database
* Set the default size to `100` (This was the previous value)

# Motivation

I was running into the same issue when dumping tables bigger than 100MB (https://github.com/Qovery/Replibyte/issues/208). The order of the Statements were wrong and I was not able to restore the dumps. I still don't know 100% what is cause the issue but it's probably related when the compressed chunks are being read from the datastore and are being restored in the wrong order.

So, this PR aims to make the arguments more flexible and serve as a workaround for the issue above.
