### PR TITLE
fix: Add utf-8 parsing error handling

### DIFF
--- a/dump-parser/src/utils.rs
+++ b/dump-parser/src/utils.rs
@@ -71,7 +71,13 @@ where
             let mut buf_bytes_to_keep: Vec<u8> = Vec::new();
 
             if buf_bytes.len() > 1 {
-                let query_str = str::from_utf8(buf_bytes.as_slice()).unwrap(); // FIXME remove unwrap
+                let query_str = match str::from_utf8(buf_bytes.as_slice()) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        warning!("Failed to parse {} as utf-8. Skipping query.", buf_bytes.as_slice())
+                        continue
+                    }
+                };
 
                 for statement in list_statements(query_str) {
                     match statement {

--- a/dump-parser/src/utils.rs
+++ b/dump-parser/src/utils.rs
@@ -73,10 +73,7 @@ where
             if buf_bytes.len() > 1 {
                 let query_str = match str::from_utf8(buf_bytes.as_slice()) {
                     Ok(t) => t,
-                    Err(e) => {
-                        warning!("Failed to parse {} as utf-8. Skipping query.", buf_bytes.as_slice())
-                        continue
-                    }
+                    Err(e) => continue
                 };
 
                 for statement in list_statements(query_str) {


### PR DESCRIPTION
Fixes #220

Utf-8 parse errors affect users, and given the choice between panicking and skipping a query, the latter seems like the better option.

There might be a third option I'm not seeing though. Let me know if you prefer to solve this another way 👍 