### PR TITLE
Correct filename

### DIFF
--- a/website/docs/guides/deploy-replibyte/container.md
+++ b/website/docs/guides/deploy-replibyte/container.md
@@ -43,7 +43,7 @@ I will take our final `conf.yaml` file from the ["create a dump"](/docs/guides/c
 
 :::caution
 
-You must name your replibyte configuration file `replibyte.conf`. Otherwise, it will not work.
+You must name your replibyte configuration file `replibyte.yaml`. Otherwise, it will not work.
 
 :::
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25310870/202559260-7d95e23d-8ebe-445c-ab42-0666341d1552.png)

Looks like the warning banner has a typo