### PR TITLE
Fix #237: Add Prefix to File Chunks 

### DIFF
--- a/replibyte/src/datastore/local_disk.rs
+++ b/replibyte/src/datastore/local_disk.rs
@@ -124,7 +124,7 @@ impl Datastore for LocalDisk {
 
         let data_size = data.len();
         let dump_dir_path = format!("{}/{}", self.dir, self.dump_name);
-        let dump_file_path = format!("{}/{}.dump", dump_dir_path, file_part);
+        let dump_file_path = format!("{}/{:02}.dump", dump_dir_path, file_part);
 
         // create the dump directory if needed
         DirBuilder::new()
@@ -314,7 +314,7 @@ mod tests {
 
         // part 1 of dump should exists
         assert!(Path::new(&format!(
-            "{}/{}/1.dump",
+            "{}/{}/01.dump",
             dir.path().to_str().unwrap(),
             dump.directory_name
         ))

--- a/replibyte/src/datastore/local_disk.rs
+++ b/replibyte/src/datastore/local_disk.rs
@@ -124,7 +124,7 @@ impl Datastore for LocalDisk {
 
         let data_size = data.len();
         let dump_dir_path = format!("{}/{}", self.dir, self.dump_name);
-        let dump_file_path = format!("{}/{:02}.dump", dump_dir_path, file_part);
+        let dump_file_path = format!("{}/{:04}.dump", dump_dir_path, file_part);
 
         // create the dump directory if needed
         DirBuilder::new()
@@ -314,7 +314,7 @@ mod tests {
 
         // part 1 of dump should exists
         assert!(Path::new(&format!(
-            "{}/{}/01.dump",
+            "{}/{}/0001.dump",
             dir.path().to_str().unwrap(),
             dump.directory_name
         ))

--- a/replibyte/src/datastore/s3.rs
+++ b/replibyte/src/datastore/s3.rs
@@ -314,9 +314,9 @@ fn write_objects<B: Datastore>(
     };
 
     let data_size = data.len();
-    let key = format!("{}/{}.dump", root_key, file_part);
+    let key = format!("{}/{:02}.dump", root_key, file_part);
 
-    info!("upload object '{}' part {} on", key.as_str(), file_part);
+    info!("upload object '{}' part {:02} on", key.as_str(), file_part);
 
     let _ = create_object(client, bucket, key.as_str(), data)?;
 

--- a/replibyte/src/datastore/s3.rs
+++ b/replibyte/src/datastore/s3.rs
@@ -314,9 +314,9 @@ fn write_objects<B: Datastore>(
     };
 
     let data_size = data.len();
-    let key = format!("{}/{:02}.dump", root_key, file_part);
+    let key = format!("{}/{:04}.dump", root_key, file_part);
 
-    info!("upload object '{}' part {:02} on", key.as_str(), file_part);
+    info!("upload object '{}' part {:04} on", key.as_str(), file_part);
 
     let _ = create_object(client, bucket, key.as_str(), data)?;
 


### PR DESCRIPTION
Fixes #237.

This PR adds trailing zeros when storing the dump chunks. This is done in order to keep the correct file order when restoring dumps. Instead of outputting `1.dump` the code now outputs `0001.dump`.

The issue is described here: https://github.com/Qovery/Replibyte/issues/237