### PR TITLE
Fix: #233 | Use get_bucket_location to check if S3 Bucket exists

### DIFF
--- a/replibyte/src/datastore/s3.rs
+++ b/replibyte/src/datastore/s3.rs
@@ -428,19 +428,14 @@ fn create_bucket<'a, S: AsRef<str>>(
 
     let cfg = cfg.build();
 
-    if let Ok(output) = block_on(client.list_buckets().send()) {
-        if let Some(buckets) = output.buckets {
-            if buckets.iter().any(|b| {
-                if let Some(name) = &b.name {
-                    name == bucket
-                } else {
-                    false
-                }
-            }) {
-                info!("bucket {} exists", bucket);
-                return Ok(());
-            }
-        }
+    if let Ok(_) = block_on(
+        client
+            .get_bucket_location()
+            .bucket(bucket)
+            .send(),
+    ) {
+        info!("bucket {} exists", bucket);
+        return Ok(());
     }
 
     let result = block_on(


### PR DESCRIPTION
Fixes: #233.

Use `get_bucket_location()` method to check if S3 bucket exists instead of listing all the S3 buckets in a AWS account. This should allow the user to use S3 buckets in a another account (cross-account) if desired.

This should also fix the CORS error reported in this PR: https://github.com/Qovery/Replibyte/pull/212