### PR TITLE
[docs] Add documentation about only_tables and skip options

### DIFF
--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -100,7 +100,7 @@ source:
       table: customers
 ```
 
-### Exclude strategy (`skip_tables`)
+### Exclude strategy (`skip`)
 
 Add a key named `skip` under the `source`:
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -166,6 +166,12 @@ source:
       table: orders
     - database: public
       table: customers
+  # skip: # optional - exclude from the dump the specified tables.
+  #   - database: public
+  #     table: us_states
+  #   - database: public
+  #     table: order_details
+
 datastore:
   aws:
     bucket: $BUCKET_NAME

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -78,6 +78,54 @@ Any datastore compatible with the S3 protocol is a valid datastore.
 
 :::
 
+## Select tables from the source
+
+You have the possibility to select which tables you want in the dump.
+
+There are two options to achieve this:
+ 1. By specifying a list of tables you want (include strategy)
+ 2. By skipping a list of tables you don't want (exclude strategy)
+
+### Include strategy (`only_tables`)
+
+Add a key named `only_tables` under the `source`:
+
+```yaml
+source:
+  connection_uri: postgres://root:password@localhost:5432/root
+  only_tables: # optional - dumps only specified tables.
+    - database: public
+      table: orders
+    - database: public
+      table: customers
+```
+
+### Exclude strategy (`skip_tables`)
+
+Add a key named `skip` under the `source`:
+
+```yaml
+source:
+  connection_uri: postgres://root:password@localhost:5432/root
+  skip: # optional - exclude from the dump the specified tables.
+    - database: public
+      table: us_states
+    - database: public
+      table: order_details
+```
+
+This will exclude from the dump the tables `us_states` and `order_details`.
+
+:::warning
+
+This will exclude the table schema AND the table data.
+:::
+
+:::warning
+
+Currently only PostgreSQL and MySQL sources support this feature.
+:::
+
 ## Example
 
 Here is a configuration file including some transformations and different options like the database subset.


### PR DESCRIPTION
I were looking for more documentation about some options to choose which table I can include or exclude from the dump.

Related to #225

It's the first time I use Replibyte and I'm not familiar with Rust. This is what I found in the issue queue and by looking at the code.