### PR TITLE
fix: handle scientific notation literal numbers

### DIFF
--- a/dump-parser/src/postgres/mod.rs
+++ b/dump-parser/src/postgres/mod.rs
@@ -572,6 +572,22 @@ impl<'a> Tokenizer<'a> {
             return Ok(Some(Token::Period));
         }
 
+        // match scientific notation
+        // copilot generated
+        if let Some(ch) = chars.peek() {
+            if ch == &'e' || ch == &'E' {
+                s.push('e');
+                chars.next();
+                if let Some(ch) = chars.peek() {
+                    if ch == &'+' || ch == &'-' {
+                        s.push(*ch);
+                        chars.next();
+                    }
+                }
+                s += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
+            }
+        }
+
         let long = if chars.peek() == Some(&'L') {
             chars.next();
             true


### PR DESCRIPTION
Replibyte was crashing with the following error:
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `6`,
 right: `8`: Column names do not match values: got 6 names and 8 values', replibyte/src/source/postgres.rs:364:5
stack backtrace:
   0:        0x1054fcea2 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h4cae82d438451481
   1:        0x10552432b - core::fmt::write::hb68c3045179d0cad
   2:        0x1054f49fe - std::io::Write::write_fmt::haf84c797e63d79f0
   3:        0x1054ff600 - std::panicking::default_hook::{{closure}}::he18137441e51da1f
   4:        0x1054ff2e6 - std::panicking::default_hook::ha3efe84526f027fa
   5:        0x1054ffd5d - std::panicking::rust_panic_with_hook::h429a7ddefa5f0258
   6:        0x1054ffa83 - std::panicking::begin_panic_handler::{{closure}}::h9b033a6b15b84a74
   7:        0x1054fd337 - std::sys_common::backtrace::__rust_end_short_backtrace::hcdd3bec8e0e38aa6
   8:        0x1054ff74a - _rust_begin_unwind
   9:        0x105585c53 - core::panicking::panic_fmt::hf7d6e5207e013f69
  10:        0x1055218a2 - core::panicking::assert_failed_inner::h4f83220ebb7940b8
  11:        0x10552dd0e - core::panicking::assert_failed::h55a24e47d080d22b
  12:        0x10489fb77 - replibyte::source::postgres::transform_columns::h1d30d7c2ec1335f1
  13:        0x1048df98b - replibyte::source::postgres::read_and_transform::{{closure}}::h3588686a03f0222e
  14:        0x1048d7e5f - dump_parser::utils::list_sql_queries_from_dump_reader::h902ca7163cdaec01
  15:        0x1048a1c05 - <replibyte::tasks::full_dump::FullDumpTask<S> as replibyte::tasks::Task>::run::h06fe238bef6ee5df
  16:        0x10484d3d6 - replibyte::commands::dump::run::h962f7069e91567b0
  17:        0x10490f939 - replibyte::main::h5ce70d1adabfa1ae
  18:        0x104840b26 - std::sys_common::backtrace::__rust_begin_short_backtrace::h1f7659dc90a8beea
  19:        0x1048c45cc - std::rt::lang_start::{{closure}}::h45b5fc87a1302c9f
  20:        0x1054fc5d5 - std::rt::lang_start_internal::hef78d5782ed29805
  21:        0x104916309 - _main
```
In `transform_columns`  in `posrgres.rs, column_names length is asserted to be equal to column_values length.

Values were 8 (instead of six) because number in scientific notation where considered as 3 tokens instead of 1, hence the proposed fix.  