### PR TITLE
Parse passwords with special chars correctly

### DIFF
--- a/replibyte/src/config.rs
+++ b/replibyte/src/config.rs
@@ -424,7 +424,9 @@ fn get_username(url: &Url) -> Result<String, Error> {
 
 fn get_password(url: &Url) -> Result<String, Error> {
     match url.password() {
-        Some(password) => Ok(password.to_string()),
+        Some(password) => Ok(percent_decode_str(&password)
+			.decode_utf8_lossy()
+			.to_string()),
         None => Ok(String::new()), // no password
     }
 }
@@ -614,6 +616,20 @@ mod tests {
                 5432,
                 "root@azure".to_string(),
                 "password".to_string(),
+                "db".to_string(),
+            ),
+        )
+    }
+
+	#[test]
+    fn parse_postgres_connection_uri_with_password_with_special_chars_db() {
+        assert_eq!(
+            parse_connection_uri("postgres://root:%aqdz^e@localhost:5432/db").unwrap(),
+            ConnectionUri::Postgres(
+                "localhost".to_string(),
+                5432,
+                "root".to_string(),
+                "%aqdz^e".to_string(),
                 "db".to_string(),
             ),
         )


### PR DESCRIPTION
What:
Could not connect to Postgresql DBs using passwords with special characters.

Fix:
Implement url decoding for password passed to Postgresql config

Tests:
Passing